### PR TITLE
Add BMO worker provisioning, remove obsolete day2 ISO logic

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -89,3 +89,46 @@ SANITY_TESTS_PODS_WORKLOAD_FILE=manifests/post-installation-manual/workload.yaml
 SANITY_TESTS_WORKLOAD_NAMESPACE=workload
 SANITY_TESTS_PING_COUNT=20
 SANITY_TESTS_PING_HBN_TO_HBN_PODS=false
+
+# =============================================================================
+# Worker Node Provisioning Configuration
+# =============================================================================
+# Automated provisioning of worker nodes via Bare Metal Operator (BMO) and Redfish.
+# Auto-discovery for all Redfish BMCs. Let ironic figure out vendor-specific paths.
+
+# Number of workers to provision (0 = skip worker provisioning)
+WORKER_COUNT=0
+
+# Worker 1 Configuration (uncomment and set WORKER_COUNT=1)
+#WORKER_1_NAME=openshift-worker-1
+#WORKER_1_BMC_IP=192.168.1.101
+#WORKER_1_BMC_USER=root
+#WORKER_1_BMC_PASSWORD=calvin
+#WORKER_1_BOOT_MAC=aa:bb:cc:dd:ee:01
+#WORKER_1_ROOT_DEVICE=/dev/sda
+
+# Worker 2 Configuration (uncomment and set WORKER_COUNT=2)
+#WORKER_2_NAME=openshift-worker-2
+#WORKER_2_BMC_IP=192.168.1.102
+#WORKER_2_BMC_USER=root
+#WORKER_2_BMC_PASSWORD=calvin
+#WORKER_2_BOOT_MAC=aa:bb:cc:dd:ee:02
+#WORKER_2_ROOT_DEVICE=/dev/sda
+
+# Variable descriptions:
+#   WORKER_n_NAME        - Worker hostname (must be unique per worker)
+#   WORKER_n_BMC_IP      - BMC/iDRAC IP address for Redfish API access
+#   WORKER_n_BMC_USER    - BMC username for authentication
+#   WORKER_n_BMC_PASSWORD - BMC password for authentication
+#   WORKER_n_BOOT_MAC    - Boot NIC MAC address (used for PXE/network boot)
+#   WORKER_n_ROOT_DEVICE - Target installation disk device path
+
+# CSR Auto-Approval (SECURITY WARNING)
+# Set to 'true' for fully hands-off provisioning.
+# WARNING: Only enable in trusted environments. Automatically approves
+# certificate signing requests from worker nodes.
+AUTO_APPROVE_WORKER_CSR=false
+
+# CSR approval timeout in seconds (default: 600 = 10 minutes)
+# Only used when AUTO_APPROVE_WORKER_CSR=true
+CSR_APPROVAL_TIMEOUT=600

--- a/manifests/worker-provisioning/baremetalhost.yaml
+++ b/manifests/worker-provisioning/baremetalhost.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: metal3.io/v1alpha1
+kind: BareMetalHost
+metadata:
+  name: <WORKER_NAME>
+  namespace: openshift-machine-api
+  annotations:
+    inspect.metal3.io: disabled
+spec:
+  online: true
+  bootMACAddress: <BOOT_MAC>
+  bmc:
+    address: redfish-virtualmedia+https://<BMC_IP>
+    credentialsName: <WORKER_NAME>-bmc-secret
+    disableCertificateVerification: true
+  customDeploy:
+    method: install_coreos
+  rootDeviceHints:
+    deviceName: <ROOT_DEVICE>
+  userData:
+    name: worker-user-data-managed
+    namespace: openshift-machine-api

--- a/manifests/worker-provisioning/bmc-secret.yaml
+++ b/manifests/worker-provisioning/bmc-secret.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: <WORKER_NAME>-bmc-secret
+  namespace: openshift-machine-api
+type: Opaque
+data:
+  username: <BMC_USER_BASE64>
+  password: <BMC_PASSWORD_BASE64>

--- a/manifests/worker-provisioning/provisioning.yaml
+++ b/manifests/worker-provisioning/provisioning.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: metal3.io/v1alpha1
+kind: Provisioning
+metadata:
+  name: provisioning-configuration
+spec:
+  provisioningNetwork: "Disabled"
+  watchAllNamespaces: false

--- a/scripts/worker.sh
+++ b/scripts/worker.sh
@@ -1,0 +1,176 @@
+#!/bin/bash
+# worker.sh - Worker node provisioning via BMO/Redfish
+
+set -e
+set -o pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/env.sh"
+source "${SCRIPT_DIR}/utils.sh"
+
+# Use existing path conventions from env.sh
+WORKER_TEMPLATE_DIR="${MANIFESTS_DIR}/worker-provisioning"
+WORKER_GENERATED_DIR="${GENERATED_DIR}/worker-provisioning"
+
+
+provision_all_workers() {
+    local count="${WORKER_COUNT:-0}"
+    [[ "$count" -eq 0 ]] && { log "INFO" "WORKER_COUNT=0, skipping"; return 0; }
+
+    # BMO is pre-installed in OpenShift - verify it's available
+    if ! oc get clusteroperator baremetal &>/dev/null; then
+        log "ERROR" "Baremetal cluster operator not found. This should not happen in OpenShift."
+        return 1
+    fi
+
+    # Ensure Provisioning CR exists (apply_manifest handles existence check)
+    apply_manifest "${WORKER_TEMPLATE_DIR}/provisioning.yaml" false
+
+    mkdir -p "${WORKER_GENERATED_DIR}"
+    log "INFO" "Provisioning ${count} worker(s)..."
+
+    for i in $(seq 1 "$count"); do
+        local name_var="WORKER_${i}_NAME"
+        local name="${!name_var}"
+        [[ -z "$name" ]] && { log "ERROR" "${name_var} not set"; return 1; }
+
+        # Skip if already exists (idempotent)
+        if oc get bmh -n openshift-machine-api "$name" &>/dev/null; then
+            log "INFO" "BMH $name already exists, skipping"
+            continue
+        fi
+
+        # Get worker config via indirect expansion
+        local bmc_ip_var="WORKER_${i}_BMC_IP"; local bmc_ip="${!bmc_ip_var}"
+        local bmc_user_var="WORKER_${i}_BMC_USER"; local bmc_user="${!bmc_user_var}"
+        local bmc_pass_var="WORKER_${i}_BMC_PASSWORD"; local bmc_pass="${!bmc_pass_var}"
+        local boot_mac_var="WORKER_${i}_BOOT_MAC"; local boot_mac="${!boot_mac_var}"
+        local root_dev_var="WORKER_${i}_ROOT_DEVICE"; local root_dev="${!root_dev_var:-/dev/sda}"
+
+        # Validate required vars
+        [[ -z "$bmc_ip" ]] && { log "ERROR" "WORKER_${i}_BMC_IP not set"; return 1; }
+        [[ -z "$bmc_user" ]] && { log "ERROR" "WORKER_${i}_BMC_USER not set"; return 1; }
+        [[ -z "$bmc_pass" ]] && { log "ERROR" "WORKER_${i}_BMC_PASSWORD not set"; return 1; }
+        [[ -z "$boot_mac" ]] && { log "ERROR" "WORKER_${i}_BOOT_MAC not set"; return 1; }
+
+        log "INFO" "Creating manifests for $name..."
+
+        # Generate BMC secret using process_template
+        process_template \
+            "${WORKER_TEMPLATE_DIR}/bmc-secret.yaml" \
+            "${WORKER_GENERATED_DIR}/${name}-bmc-secret.yaml" \
+            "<WORKER_NAME>" "$name" \
+            "<BMC_USER_BASE64>" "$(printf '%s' "$bmc_user" | base64)" \
+            "<BMC_PASSWORD_BASE64>" "$(printf '%s' "$bmc_pass" | base64)"
+
+        # Generate BareMetalHost using process_template
+        process_template \
+            "${WORKER_TEMPLATE_DIR}/baremetalhost.yaml" \
+            "${WORKER_GENERATED_DIR}/${name}-bmh.yaml" \
+            "<WORKER_NAME>" "$name" \
+            "<BOOT_MAC>" "$boot_mac" \
+            "<BMC_IP>" "$bmc_ip" \
+            "<ROOT_DEVICE>" "$root_dev"
+
+        # Apply manifests
+        apply_manifest "${WORKER_GENERATED_DIR}/${name}-bmc-secret.yaml" false
+        apply_manifest "${WORKER_GENERATED_DIR}/${name}-bmh.yaml" false
+        log "INFO" "BMH $name created"
+    done
+
+    log "INFO" "Worker provisioning initiated"
+}
+
+approve_worker_csrs() {
+    # Approve all pending CSRs - simple and effective for worker provisioning
+    # OpenShift's cluster-machine-approver handles normal CSR approval,
+    # but we need to approve CSRs for BMO-provisioned workers manually
+    local approved=0
+    local csr
+
+    for csr in $(oc get csr -o go-template='{{range .items}}{{if not .status}}{{.metadata.name}}{{"\n"}}{{end}}{{end}}' 2>/dev/null); do
+        if oc adm certificate approve "$csr" 2>/dev/null; then
+            log "INFO" "Approved CSR $csr"
+            ((approved++)) || true
+        fi
+    done
+
+    [[ $approved -gt 0 ]] && log "INFO" "Approved $approved CSR(s)" || true
+}
+
+is_worker_registered() {
+    # Check if worker's BMH is in provisioned state
+    # This means the worker has been fully provisioned and should be a node
+    local bmh_name="$1"
+
+    # Check BMH provisioning state - if "provisioned", the worker is done
+    local bmh_state
+    bmh_state=$(oc get bmh -n openshift-machine-api "$bmh_name" \
+        -o jsonpath='{.status.provisioning.state}' 2>/dev/null)
+    [[ "$bmh_state" == "provisioned" ]] && return 0
+
+    return 1
+}
+
+wait_and_approve_csrs() {
+    local timeout="${CSR_APPROVAL_TIMEOUT:-600}"
+    local count="${WORKER_COUNT:-0}"
+    local end=$((SECONDS + timeout))
+
+    # Check if all workers already registered (skip wait if so)
+    local ready=0
+    for i in $(seq 1 "$count"); do
+        local name_var="WORKER_${i}_NAME"
+        local bmh_name="${!name_var}"
+        is_worker_registered "$bmh_name" && ((ready++)) || true
+    done
+    [[ "$ready" -ge "$count" ]] && { log "INFO" "All $count workers already registered, skipping CSR wait"; return 0; }
+
+    log "INFO" "Waiting for CSRs (timeout: ${timeout}s)..."
+
+    while [[ $SECONDS -lt $end ]]; do
+        approve_worker_csrs
+
+        # Check if all workers registered
+        local ready=0
+        for i in $(seq 1 "$count"); do
+            local name_var="WORKER_${i}_NAME"
+            local bmh_name="${!name_var}"
+            is_worker_registered "$bmh_name" && ((ready++)) || true
+        done
+
+        [[ "$ready" -ge "$count" ]] && { log "INFO" "All $count workers registered"; return 0; }
+        sleep 30
+    done
+
+    log "WARN" "Timeout - some workers may need manual CSR approval"
+}
+
+display_worker_status() {
+    echo "=== Worker Status ==="
+    oc get bmh -n openshift-machine-api
+    echo ""
+    echo "=== Nodes ==="
+    oc get nodes
+}
+
+display_manual_csr_instructions() {
+    echo ""
+    echo "To approve CSRs manually:"
+    echo "  oc get csr | grep Pending"
+    echo "  oc adm certificate approve <csr-name>"
+    echo "Or: make approve-worker-csrs"
+}
+
+# Command dispatcher
+case "${1:-}" in
+    provision-all-workers) provision_all_workers ;;
+    approve-worker-csrs) approve_worker_csrs ;;
+    wait-and-approve-csrs) wait_and_approve_csrs ;;
+    display-worker-status) display_worker_status ;;
+    display-manual-csr-instructions) display_manual_csr_instructions ;;
+    *)
+        echo "Usage: $0 {provision-all-workers|approve-worker-csrs|wait-and-approve-csrs|display-worker-status|display-manual-csr-instructions}"
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
## Summary
- Add worker node provisioning via Bare Metal Operator and Redfish API
- Remove obsolete day2 ISO creation logic (BMO generates ISO automatically)
- Integrate worker provisioning into `make all` target

## Changes
- `scripts/worker.sh` - New minimal BMO provisioning script (169 lines)
- `Makefile` - Add worker targets, remove day2 targets
- `scripts/cluster.sh` - Remove `create_day2_cluster()` function
- `.env.example` - Add WORKER_* configuration variables

## Test plan
- [x] Tested on live cluster with Dell iDRAC
- [x] BMH state progression verified: registering → preparing → provisioning
- [x] Idempotency verified (re-run skips existing BMH)
- [x] All Makefile targets tested

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Worker node provisioning using Bare Metal Operator with per-worker templated configurations
  * Configuration support for total worker count, individual BMC credentials, CSR auto-approval, and approval timeout
  * Automatic generation and application of provisioning manifests for each worker node
  * Commands for monitoring provisioned worker status and managing CSR approvals (automatic or manual)

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->