### PR TITLE
feat: enable mutatingadmissionpolicy in cluster

### DIFF
--- a/manifests/cluster-installation/openshift/99_feature-gate.yaml
+++ b/manifests/cluster-installation/openshift/99_feature-gate.yaml
@@ -1,0 +1,9 @@
+apiVersion: config.openshift.io/v1
+kind: FeatureGate
+metadata:
+  name: cluster
+spec:
+  featureSet: CustomNoUpgrade
+  customNoUpgrade:
+    enabled:
+    - MutatingAdmissionPolicy

--- a/scripts/enable-ovn-injector.sh
+++ b/scripts/enable-ovn-injector.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# enable-ovn-injector.sh - Enable OVN resource injector
+# enable-ovn-injector.sh - Enable OVN resource injector via MutatingAdmissionPolicy
 
 # Exit on error
 set -e
@@ -19,31 +19,43 @@ get_kubeconfig
 # Ensure helm is installed
 ensure_helm_installed
 
-log [INFO] "Enabling OVN resource injector..."
+log [INFO] "Enabling OVN resource injector via MutatingAdmissionPolicy..."
 
-rm -rf "$GENERATED_DIR/ovn-injector" | true
+rm -rf "$GENERATED_DIR/ovn-injector" || true
 mkdir -p "$GENERATED_DIR/ovn-injector"
 
 INJECTOR_RESOURCE_NAME="${INJECTOR_RESOURCE_NAME:-openshift.io/bf3-p0-vfs}"
+
+# Escape the resource name for JSON Patch path (/ becomes ~1)
+INJECTOR_RESOURCE_NAME_ESCAPED=$(echo "${INJECTOR_RESOURCE_NAME}" | sed 's/\//~1/g')
+
+# Patch control plane nodes with fake resource capacity/allocatable
+# This is required for the MutatingAdmissionPolicy to work correctly.
+# All control plane nodes are patched with a high number of resources with the same name as the VF resource
+# exposed by the device plugin. These devices are only exposed on the Node and have no device plugin managing allocations.
+# Pods scheduled to the control plane nodes will consume these resources, but Multus will not use them when it calls the
+# OVN Kubernetes CNI for pod creation. This is because these devices will not be advertised by kubelet's podresources API.
+#
+# NOTE: This patch only applies to existing control plane nodes at the time this script runs.
+#       Any new control plane nodes added to the cluster will need to be patched manually.
+log [INFO] "Patching control plane nodes with resource capacity..."
+for node in $(oc get nodes -l node-role.kubernetes.io/control-plane -o jsonpath='{.items[*].metadata.name}'); do
+    log [INFO] "Patching node: $node"
+    oc patch node "$node" --subresource=status --type=json -p="[
+        {\"op\": \"add\", \"path\": \"/status/capacity/${INJECTOR_RESOURCE_NAME_ESCAPED}\", \"value\": \"10000\"},
+        {\"op\": \"add\", \"path\": \"/status/allocatable/${INJECTOR_RESOURCE_NAME_ESCAPED}\", \"value\": \"10000\"}
+    ]"
+done
+log [INFO] "Control plane nodes patched successfully"
 
 helm pull "${OVN_CHART_URL}/ovn-kubernetes-chart" \
     --version "${INJECTOR_CHART_VERSION}" \
     --untar -d "$GENERATED_DIR/ovn-injector"
 
-injector_image_params=()
-if [ -n "${INJECTOR_IMAGE:-}" ]; then
-    injector_image_params=(
-        --set "ovn-kubernetes-resource-injector.controllerManager.webhook.image.repository=${INJECTOR_IMAGE%:*}"
-        --set "ovn-kubernetes-resource-injector.controllerManager.webhook.image.tag=${INJECTOR_IMAGE#*:}"
-    )
-fi
-
-helm template -n ${OVNK_NAMESPACE} ovn-kubernetes-resource-injector \
+helm template -n ${OVNK_NAMESPACE} ovn-kubernetes \
     "$GENERATED_DIR/ovn-injector/ovn-kubernetes-chart" \
     --set ovn-kubernetes-resource-injector.enabled=true \
-    --set ovn-kubernetes-resource-injector.resourceName="${INJECTOR_RESOURCE_NAME}" \
-    --set ovn-kubernetes-resource-injector.nadName=dpf-ovn-kubernetes \
-    "${injector_image_params[@]}" \
+    --set resourceName="${INJECTOR_RESOURCE_NAME}" \
     --set nodeWithDPUManifests.enabled=false \
     --set nodeWithoutDPUManifests.enabled=false \
     --set dpuManifests.enabled=false \
@@ -53,10 +65,14 @@ helm template -n ${OVNK_NAMESPACE} ovn-kubernetes-resource-injector \
 
 rm -rf "$GENERATED_DIR/ovn-injector"
 
-
-# Wait for injector to be ready
-log [INFO] "Waiting for OVN injector deployment to be ready..."
-wait_for_pods "${OVNK_NAMESPACE}" "app.kubernetes.io/name=ovn-kubernetes-resource-injector" 30 10
+# Verify MutatingAdmissionPolicy creation
+log [INFO] "Verifying OVN injector MutatingAdmissionPolicy creation..."
+if oc get mutatingadmissionpolicies.admissionregistration.k8s.io ovn-kubernetes-resource-injector &>/dev/null; then
+    log [INFO] "MutatingAdmissionPolicy 'ovn-kubernetes-resource-injector' created successfully"
+else
+    log [ERROR] "MutatingAdmissionPolicy 'ovn-kubernetes-resource-injector' was not created"
+    exit 1
+fi
 
 # Verify NAD creation
 if oc get net-attach-def -n "${OVNK_NAMESPACE}" dpf-ovn-kubernetes &>/dev/null; then

--- a/scripts/manifests.sh
+++ b/scripts/manifests.sh
@@ -183,6 +183,14 @@ function prepare_cluster_manifests() {
     else
         log [INFO] "Installing manifests to cluster via AICLI..."
         aicli create manifests --dir "$GENERATED_DIR" "$CLUSTER_NAME"
+
+        # Upload openshift folder manifests (e.g., FeatureGate) to the openshift folder
+        # This is needed to override built-in OpenShift manifests like 99_feature-gate.yaml
+        local openshift_manifests_dir="$MANIFESTS_DIR/cluster-installation/openshift"
+        if [ -d "$openshift_manifests_dir" ] && [ "$(ls -A "$openshift_manifests_dir" 2>/dev/null)" ]; then
+            log [INFO] "Installing openshift folder manifests (to override built-in manifests)..."
+            aicli create manifests --dir "$openshift_manifests_dir" --openshift "$CLUSTER_NAME"
+        fi
     fi
 
     log [INFO] "Cluster manifests preparation complete."


### PR DESCRIPTION
enable the mutatingadmissionpolicy in the cluster on installation

This feature can be used to replace webhooks - particularly the ovn kubernetes resource injector

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added OpenShift-specific manifest override capability for cluster installations with dedicated configuration support
  * Enabled MutatingAdmissionPolicy support in OpenShift feature configuration

* **Improvements**
  * Enhanced OVN injector setup with improved reliability, resource node provisioning, and verification mechanisms
  * Improved error handling and cleanup procedures in installation scripts

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->