### PR TITLE
Fix: Remove keepalived from worker nodes to prevent VIP conflicts

### DIFF
--- a/manifests/cluster-installation/99-worker-remove-keepalived.yaml
+++ b/manifests/cluster-installation/99-worker-remove-keepalived.yaml
@@ -1,0 +1,29 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: worker
+  name: 99-worker-remove-keepalived
+spec:
+  config:
+    ignition:
+      version: 3.2.0
+    systemd:
+      units:
+        - name: remove-keepalived-manifest.service
+          enabled: true
+          contents: |
+            [Unit]
+            Description=Remove keepalived static pod manifest from worker nodes
+            Documentation=https://github.com/nvidia/openshift-dpf
+            Before=kubelet.service
+            ConditionPathExists=/etc/kubernetes/manifests/keepalived.yaml
+            
+            [Service]
+            Type=oneshot
+            ExecStart=/bin/bash -c 'rm -f /etc/kubernetes/manifests/keepalived.yaml && echo "Removed keepalived manifest from worker node"'
+            RemainAfterExit=yes
+            
+            [Install]
+            WantedBy=multi-user.target
+

--- a/manifests/cluster-installation/99-worker-remove-keepalived.yaml
+++ b/manifests/cluster-installation/99-worker-remove-keepalived.yaml
@@ -15,7 +15,7 @@ spec:
           contents: |
             [Unit]
             Description=Remove keepalived static pod manifest from worker nodes
-            Documentation=https://github.com/nvidia/openshift-dpf
+            Documentation=https://github.com/rh-ecosystem-edge/openshift-dpf
             Before=kubelet.service
             ConditionPathExists=/etc/kubernetes/manifests/keepalived.yaml
             


### PR DESCRIPTION
It seems like in a setup created by the automation, API VIPs can be assigned to all nodes including Worker nodes.
This prevented me to re-deploy a cluster, as the worker nodes of a destroyed cluster was holding the VIP.
The fix:
Adds MachineConfig to remove keepalived static pod manifest from worker nodes. This prevents workers from participating in VRRP and claiming cluster VIPs, which causes installation failures with 'ingress vips already in use' error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic removal of keepalived configuration from worker nodes during cluster initialization to ensure proper node setup and prevent stale or conflicting networking configuration. This runs as part of the node boot sequence and confirms removal when present, improving cluster stability and reducing manual cleanup after provisioning for administrators.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->