### PR TITLE
feat: bump hbn image to public release

### DIFF
--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -67,8 +67,8 @@ HBN_OVN_NETWORK=${HBN_OVN_NETWORK:-"10.0.120.0/22"}
 # HBN Service Template Configuration
 HBN_HELM_REPO_URL=${HBN_HELM_REPO_URL:-"https://helm.ngc.nvidia.com/nvidia/doca"}
 HBN_HELM_CHART_VERSION=${HBN_HELM_CHART_VERSION:-"1.0.3"}
-HBN_IMAGE_REPO=${HBN_IMAGE_REPO:-"quay.io/eelgaev/doca_hbn"}
-HBN_IMAGE_TAG=${HBN_IMAGE_TAG:-"release-3.1.0.7-doca3.1.0-RHTP"}
+HBN_IMAGE_REPO=${HBN_IMAGE_REPO:-"nvcr.io/nvidia/doca/doca_hbn"}
+HBN_IMAGE_TAG=${HBN_IMAGE_TAG:-"3.2.0-doca3.2.0"}
 
 # DTS Service Template Configuration
 DTS_HELM_REPO_URL=${DTS_HELM_REPO_URL:-"https://helm.ngc.nvidia.com/nvidia/doca"}


### PR DESCRIPTION
change the hbn image to the public release

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores

* Updated default container image repository and tag to use the official NVIDIA registry with version 3.2.0.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->