### PR TITLE
Adding timeout to the function that waits till VFs are ready, fixes very hypothetic issue were VFs will not be ready forever

### DIFF
--- a/manifests/dpf-installation/sriov-device-plugin.yaml
+++ b/manifests/dpf-installation/sriov-device-plugin.yaml
@@ -123,11 +123,13 @@ data:
     while true; do
       TOTAL_VFS=$(cat "$PF_PATH/device/sriov_numvfs" 2>/dev/null || echo 0)
 
+      # Check timeout at the start of every iteration
+      if [ "$VF_ELAPSED" -ge "$MAX_WAIT_SECONDS" ]; then
+        log "ERROR: Timeout waiting for VFs. Exiting."
+        exit 1
+      fi
+
       if [ "$TOTAL_VFS" -le "$DATA_VF_START" ]; then
-        if [ "$VF_ELAPSED" -ge "$MAX_WAIT_SECONDS" ]; then
-          log "ERROR: Timeout waiting for VFs. Exiting."
-          exit 1
-        fi
         sleep $POLL_INTERVAL
         VF_ELAPSED=$((VF_ELAPSED + POLL_INTERVAL))
         continue
@@ -158,6 +160,7 @@ data:
         break
       fi
       sleep $POLL_INTERVAL
+      VF_ELAPSED=$((VF_ELAPSED + POLL_INTERVAL))
     done
 
     log "Generating configuration..."


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced timeout handling in SRIOV device plugin configuration for virtual function availability detection, ensuring more consistent and reliable device initialization with improved timeout accounting across all execution paths.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->