### PR TITLE
change default port for bfb registry to avoid conflict

### DIFF
--- a/manifests/dpf-installation/dpfoperatorconfig.yaml
+++ b/manifests/dpf-installation/dpfoperatorconfig.yaml
@@ -25,5 +25,7 @@ spec:
     bfCFGTemplateConfigMap: custom-bfb.cfg
     bfbPVCName: bfb-pvc
     dmsTimeout: 900
+    registry:
+      port: 8086
   staticClusterManager:
     disable: false


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added registry port configuration option for provisioning controller, enabling custom registry port settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->