### PR TITLE
Add OWNERS file for CI integration

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,9 @@
+approvers:
+- szigmon
+- tsorya
+- wabouhamad
+options: {}
+reviewers:
+- szigmon
+- tsorya
+- wabouhamad


### PR DESCRIPTION
## Summary
- Adds OWNERS file to enable Prow CI integration with openshift/release repository
- Required for PR: https://github.com/openshift/release/pull/73848

## OWNERS
```yaml
approvers:
- szigmon
- tsorya
- wabouhamad
reviewers:
- szigmon
- tsorya
- wabouhamad
```

## Why is this needed?
The openshift/release CI system requires an OWNERS file in the source repository to auto-generate OWNERS files for the CI configuration directories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal code review routing configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->