### PR TITLE
feat: add kubeadmin-password make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ WORKER_SCRIPT := scripts/worker.sh
 
 .PHONY: all clean check-cluster create-cluster prepare-manifests generate-ovn update-paths help delete-cluster verify-files \
         download-iso fix-yaml-spacing create-vms delete-vms enable-storage cluster-install wait-for-ready \
-        wait-for-installed wait-for-status cluster-start clean-all deploy-dpf kubeconfig deploy-nfd \
+        wait-for-installed wait-for-status cluster-start clean-all deploy-dpf kubeconfig kubeadmin-password deploy-nfd \
         install-hypershift install-helm deploy-dpu-services prepare-dpu-files upgrade-dpf create-day2-cluster get-day2-iso \
         redeploy-dpu enable-ovn-injector deploy-argocd deploy-maintenance-operator configure-flannel \
         deploy-core-operator-sources setup-nfs-server deploy-metallb deploy-lso deploy-odf deploy-lvms prepare-nfs run-dpf-sanity \
@@ -151,6 +151,9 @@ clean-all:
 kubeconfig:
 	@$(CLUSTER_SCRIPT) get-kubeconfig
 
+kubeadmin-password:
+	@$(CLUSTER_SCRIPT) get-kubeadmin-password
+
 deploy-nfd:
 	@$(DPF_SCRIPT) deploy-nfd
 
@@ -252,6 +255,7 @@ help:
 	@echo "  wait-for-ready    - Wait for cluster ready status"
 	@echo "  wait-for-installed - Wait for cluster installed status"
 	@echo "  kubeconfig       - Download cluster kubeconfig if not exists"
+	@echo "  kubeadmin-password - Download kubeadmin password for the cluster"
 	@echo ""
 	@echo "DPF Installation:"
 	@echo "  deploy-argocd     - Deploy GitOps operator"

--- a/scripts/cluster.sh
+++ b/scripts/cluster.sh
@@ -275,6 +275,26 @@ function get_kubeconfig() {
     fi
 }
 
+function get_kubeadmin_password() {
+    log "INFO" "Downloading kubeadmin password for cluster ${CLUSTER_NAME}..."
+    
+    if ! aicli download kubeadmin-password "${CLUSTER_NAME}"; then
+        log "ERROR" "Failed to download kubeadmin password for cluster ${CLUSTER_NAME}"
+        return 1
+    fi
+    
+    local password_file="kubeadmin-password.${CLUSTER_NAME}"
+    if [ -f "${password_file}" ]; then
+        log "INFO" "Kubeadmin password downloaded to: ${password_file}"
+        log "INFO" "Password: $(cat "${password_file}")"
+        log "INFO" "You can use this password to connect to the OpenShift console at:"
+        log "INFO" "  https://console-openshift-console.apps.${CLUSTER_NAME}.${BASE_DOMAIN}"
+        log "INFO" "  Username: kubeadmin"
+    else
+        log "WARN" "Password file not found at expected location: ${password_file}"
+    fi
+}
+
 function clean_all() {
     log "Performing full cleanup of cluster and VMs..."
     
@@ -494,6 +514,9 @@ function main() {
         get-kubeconfig)
             get_kubeconfig
             ;;
+        get-kubeadmin-password)
+            get_kubeadmin_password
+            ;;
         clean-all)
             clean_all
             ;;
@@ -517,7 +540,7 @@ function main() {
         *)
             log "Unknown command: $command"
             log "Available commands: check-create-cluster, delete-cluster, cluster-install,"
-            log "  wait-for-status, get-kubeconfig, clean-all, download-iso, create-day2-cluster, get-day2-iso, deploy-lso, deploy-odf"
+            log "  wait-for-status, get-kubeconfig, get-kubeadmin-password, clean-all, download-iso, create-day2-cluster, get-day2-iso, deploy-lso, deploy-odf"
             exit 1
             ;;
     esac


### PR DESCRIPTION
Add new make target to download the kubeadmin password using aicli. This provides a convenient way to retrieve cluster credentials after installation, including the OpenShift console URL and username.