### PR TITLE
Use VirtIO instead of e1000e for VMs

### DIFF
--- a/scripts/vm.sh
+++ b/scripts/vm.sh
@@ -84,7 +84,7 @@ function create_vms() {
            VM_MAC=$(echo "$interface_config" | jq -r '.["mac-address"]')
            VM_NAME="${VM_PREFIX}${i}"
 
-           network_full_arg="bridge=${BRIDGE_NAME},model=e1000e,mac=${VM_MAC}"
+           network_full_arg="bridge=${BRIDGE_NAME},model=virtio,mac=${VM_MAC}"
 
            log "INFO" "Starting VM creation for $VM_NAME with MAC: $VM_MAC..."
            nohup virt-install --name "$VM_NAME" --memory "$RAM" \
@@ -123,7 +123,7 @@ function create_vms() {
         fi
 
         # Construct the full --network argument string
-        network_full_arg="bridge=${BRIDGE_NAME},model=e1000e${network_mac_arg}"
+        network_full_arg="bridge=${BRIDGE_NAME},model=virtio${network_mac_arg}"
 
         # Create VM with virt-install
         log "INFO" "Starting VM creation for $VM_NAME..."


### PR DESCRIPTION
Change e1000e to virtio for stability, predictability, and saneness.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched the VM network driver model from e1000e to virtio for static and fallback VM creation paths to improve performance and hardware compatibility. MAC and bridge handling are unchanged; overall VM creation flow and networking behavior remain the same.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->