### PR TITLE
Add Containerfile for CI testing

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,0 +1,2 @@
+FROM registry.access.redhat.com/ubi9/ubi:latest
+RUN dnf install -y make git jq findutils openssh-clients rsync && dnf clean all


### PR DESCRIPTION
## Summary
- Adds Containerfile to build CI test image
- Image includes: make, git, jq, bash, findutils
- Required for Prow CI integration

## Why needed
The OpenShift CI uses this image to run tests. The base UBI9 image doesn't have `make` installed, so we need a custom image.

## Related
- openshift/release CI config uses this Containerfile
- Follows the same pattern as nvidia-ci and amd-ci

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated container configuration to specify a base runtime image and install common utilities, standardizing the runtime environment and ensuring required tools are available for building and packaging.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->