### PR TITLE
Add Containerfile and CI validation target for Prow CI

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,2 +1,2 @@
 FROM registry.access.redhat.com/ubi9/ubi:latest
-RUN dnf install -y make git jq findutils openssh-clients rsync && dnf clean all
+RUN dnf install -y make git jq findutils openssh-clients && dnf clean all

--- a/Containerfile
+++ b/Containerfile
@@ -1,2 +1,6 @@
 FROM registry.access.redhat.com/ubi9/ubi:latest
 RUN dnf install -y make git jq findutils openssh-clients && dnf clean all
+
+# Copy source code into the container
+WORKDIR /src
+COPY . .

--- a/Containerfile
+++ b/Containerfile
@@ -1,6 +1,2 @@
 FROM registry.access.redhat.com/ubi9/ubi:latest
 RUN dnf install -y make git jq findutils openssh-clients && dnf clean all
-
-# Copy source code into the container
-WORKDIR /src
-COPY . .

--- a/Makefile
+++ b/Makefile
@@ -335,3 +335,14 @@ help:
 	@echo "  WORKER_n_BMC_PASSWORD - BMC password"
 	@echo "  WORKER_n_BOOT_MAC     - Boot NIC MAC address"
 	@echo "  WORKER_n_ROOT_DEVICE  - Target installation disk (e.g., /dev/sda)" 
+
+# CI target - validates scripts without needing secrets
+ci-validate:
+	@echo "Validating shell scripts..."
+	@bash -n scripts/*.sh
+	@echo "Checking required files exist..."
+	@test -f Makefile
+	@test -f Containerfile
+	@test -d scripts
+	@test -d manifests
+	@echo "All validations passed"


### PR DESCRIPTION
## Summary
- Add Containerfile for building CI container image
- Add `ci-validate` Makefile target for CI validation
- Simplify CI container to include only essential tools

This PR enables the Prow CI integration that was added in openshift/release#74064.

## Required for CI
The Prow CI configuration expects:
- `Containerfile` at repo root for building `dpf-ci` image
- `make ci-validate` target for the validate job

## Test plan
- [ ] Merge this PR
- [ ] Verify CI jobs trigger on subsequent PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Optimized container image by removing an unused package dependency.
* **Tests**
  * Added a CI validation target that checks shell script syntax and verifies core project files/directories.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->