### PR TITLE
Fix detection of renamed worker nodes on management cluster

### DIFF
--- a/scripts/dpf-sanity-checks.sh
+++ b/scripts/dpf-sanity-checks.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Catch failures in pipelines
- set -o pipefail
+set -o pipefail
 
 # color coding for output
 RED="\e[31m"
@@ -50,13 +50,6 @@ mgmt_kubecfg="${KUBECONFIG}"
 echo -e "\n- mgmt_kubecfg: '${mgmt_kubecfg}'"
 
 # Get the hosted cluster kubeconfig
-## $ oc get hostedclusters -A --kubeconfig=${mgmt_kubecfg})
-## NAMESPACE   NAME   VERSION   KUBECONFIG              PROGRESS    AVAILABLE   PROGRESSING   MESSAGE
-## clusters    doca   4.20.0    doca-admin-kubeconfig   Completed   True        False         The hosted control plane is available
-
-## $ oc get hostedclusters -A --no-headers --kubeconfig=${mgmt_kubecfg}) | awk '{print $4}'
-## doca-admin-kubeconfig
-
 hosted_namespace=$(oc get hostedclusters -A --no-headers --kubeconfig=${mgmt_kubecfg} | awk '{print $1}')
 hosted_kubeconfig_name=$(oc get hostedclusters -A --no-headers --kubeconfig=${mgmt_kubecfg} | awk '{print $4}')
 datetime_string=$(date +"%Y-%m-%d_%H-%M-%S")
@@ -84,19 +77,38 @@ cat "${hosted_kubecfg}"
 echo -e "\nOutput of oc get nodes --kubeconfig='${mgmt_kubecfg}':"
 oc get nodes --kubeconfig="${mgmt_kubecfg}"
 
+# Find number of DPU host worker nodes on management cluster which are ready
+dpu_host_worker_list=$(oc get nodes --no-headers -l node-role.kubernetes.io/worker  --kubeconfig="${mgmt_kubecfg}" | grep -v "control-plane" | awk '$2=="Ready" && $3=="worker" {print $1}' | xargs)
+
+echo -e "\nChecking how many DPU host worker nodes are in Ready Phase on management cluster"
+if [ -z "${dpu_host_worker_list}" ]; then
+  echo "No DPU host worker nodes found in Ready Phase on management cluster"
+  exit 1
+fi
+
+# delcare empty array
+dpu_host_workers=()
+
+dpu_host_worker_count=0
+
+for i in $dpu_host_worker_list ; do
+  dpu_host_workers[${dpu_host_worker_count}]=$i
+  echo "DPU host Worker node '${dpu_host_workers[${dpu_host_worker_count}]}' is Ready";
+  ((dpu_host_worker_count++))
+done
+
+echo "Detected ${dpu_host_worker_count} DPU host workers in Ready phase"
+echo -e "Working with ${dpu_host_worker_count} DPU host worker nodes: '${dpu_host_workers[*]}'"
+
+# Find number of DPU worker nodes which are ready
 echo -e "\nOutput of oc get nodes --kubeconfig='${hosted_kubecfg}':"
 oc get nodes --kubeconfig="${hosted_kubecfg}"
-
-# Here we need to find number of DPU worker nodes which are ready
-# $ oc get dpu -n dpf-operator-system
-# NAME                                                    READY   PHASE   AGE
-# nvd-srv-27.nvidia.eng.rdu2.dc.redhat.com-mt2437600gzk   True    Ready   2d5h
-# nvd-srv-28.nvidia.eng.rdu2.dc.redhat.com-mt2437600utx   True    Ready   27h
 
 get_dpu_output=$(oc get dpu -n ${dpf_operator_namespace} --kubeconfig=${mgmt_kubecfg})
 echo -e "Output of oc get dpu:\n${get_dpu_output}"
 
-dpu_worker_list=$(oc get dpu -n ${dpf_operator_namespace} --no-headers --kubeconfig=${mgmt_kubecfg} | awk '$2=="True" && $3=="Ready" {match($1, /\.com/); if (RSTART) print substr($1, 1, RSTART+3)}' | xargs)
+# Note worker node names may not have .com and FQDN anymore, this is mainly for the kubernetes network flow tests
+dpu_worker_list=$(oc get dpu -n "${dpf_operator_namespace}" --no-headers --kubeconfig="${mgmt_kubecfg}" | awk '$2=="True" && $3=="Ready" {print $1}' | xargs)
 
 echo -e "\nChecking how many DPU worker nodes are in Ready Phase on management cluster"
 if [ -z "${dpu_worker_list}" ]; then
@@ -117,6 +129,7 @@ done
 
 echo "Detected ${dpu_worker_count} DPU workers in Ready phase"
 echo -e "Working with ${dpu_worker_count} DPU worker nodes: '${dpu_workers[*]}'"
+
 
 # counter to track number of failed test cases
 failed_testcase_count=0
@@ -368,7 +381,8 @@ doca_hbn_worker_pods=()
 for i in "${!dpu_workers[@]}"; do
   echo -e "\nFinding doca hbn pod name for DPU worker '${dpu_workers[$i]}'"
   doca_hbn_worker_pods[$i]=$(oc get pods -n "${dpf_operator_namespace}" --kubeconfig="${hosted_kubecfg}" -o wide | grep "${dpu_workers[$i]}" | grep "\-hbn\-" | awk '{print $1}')
-  ## echo -e "doca-hbn pod for worker '${dpu_workers[$i]}' found was: '${doca_hbn_worker_pods[$i]}'"
+  echo -e "doca-hbn pod for worker '${dpu_workers[$i]}' found was: '${doca_hbn_worker_pods[$i]}'"
+  
   # check that doca-hbn pod was found, otherwise exit
   if [ -z "${doca_hbn_worker_pods[$i]}" ]; then
     echo -e "❌ Failed to find doca-hbn pod for DPU worker '${dpu_workers[$i]}'"
@@ -380,7 +394,7 @@ done
 
 echo -e "\nGetting the doca-hbn container ip address for all the DPU worker nodes"
 
-#declare array doca_hbn_worker_pod_ip[]
+# declare array doca_hbn_worker_pod_ip[]
 doca_hbn_worker_pod_ip=()
 
 for i in "${!dpu_workers[@]}"; do
@@ -396,12 +410,12 @@ for i in "${!dpu_workers[@]}"; do
   fi
 done
 
-# oc get pods -n ${SANITY_TESTS_WORKLOAD_NAMESPACE} --kubeconfig=${mgmt_kubecfg} -o wide
 output_workload_namespace=$(oc get pods -n  ${SANITY_TESTS_WORKLOAD_NAMESPACE} --kubeconfig=${mgmt_kubecfg} -o wide)
 
 echo -e "\nOutput of oc get pods -n ${SANITY_TESTS_WORKLOAD_NAMESPACE}: \n$output_workload_namespace\n"
 
 sriov_test_pod_master=$(oc get pods -n ${SANITY_TESTS_WORKLOAD_NAMESPACE} --kubeconfig="${mgmt_kubecfg}" | grep master | awk '{print $1}')
+
 # check that sriov master test pod was found, and running 
 if [ -z "${sriov_test_pod_master}" ]; then
   echo -e "❌ Failed to find sriov master test pod"
@@ -429,25 +443,22 @@ sriov_test_worker_pods_hostnetwork=()
 echo -e "\nRunning ping tests on all the DPU worker nodes ..."
 
 #------------  Loop throug each dpu worker node 
-for i in "${!dpu_workers[@]}"; do
+for i in "${!dpu_host_workers[@]}"; do
 
-  testcase_title="Test pings from sriov master test pod '${sriov_test_pod_master}' to doca-hbn pod '${doca_hbn_worker_pods[$i]}' on node '${dpu_workers[$i]}'"
+  testcase_title="Test pings from sriov master test pod '${sriov_test_pod_master}' to doca-hbn pod '${doca_hbn_worker_pods[$i]}' on node '${dpu_host_workers[$i]}'"
   ping_mtu_test "${testcase_title}" "${sriov_test_pod_master}" "${SANITY_TESTS_WORKLOAD_NAMESPACE}" "${mgmt_kubecfg}" "${SANITY_TESTS_PING_COUNT}" 1490 "${doca_hbn_worker_pod_ip[$i]}"
 
-  echo -e "\nFinding sriov test worker pod name for dpu_workers array index $i '${dpu_workers[$i]}' to ping doca-hbn pod name '${doca_hbn_worker_pods[$i]}'"
-  sriov_test_worker_pods[$i]=$(oc get pods -n "${SANITY_TESTS_WORKLOAD_NAMESPACE}" --kubeconfig="${mgmt_kubecfg}" -o wide | grep "${dpu_workers[$i]}" | grep "Running" | awk '{print $1}' | grep -v hostnetwork)
+  echo -e "\nFinding sriov test worker pod name for dpu_host_workers array index $i '${dpu_host_workers[$i]}' to ping doca-hbn pod name '${doca_hbn_worker_pods[$i]}'"
+  sriov_test_worker_pods[$i]=$(oc get pods -n "${SANITY_TESTS_WORKLOAD_NAMESPACE}" --kubeconfig="${mgmt_kubecfg}" -o wide | grep "${dpu_host_workers[$i]}" | grep "Running" | awk '{print $1}' | grep -v hostnetwork)
+
   if [ -z "${sriov_test_worker_pods[$i]}" ]; then
-    echo -e "❌ Failed to find sriov test worker pod for DPU worker '${dpu_workers[$i]}'. Exiting script..."
+    echo -e "❌ Failed to find sriov test worker pod for DPU worker '${dpu_host_workers[$i]}'. Exiting script..."
     exit 1
   else
-    echo -e "✅ Found sriov test worker pod for DPU worker '${dpu_workers[$i]}': '${sriov_test_worker_pods[$i]}'"
-
-    check_pod_running=$(oc get pods -n "${SANITY_TESTS_WORKLOAD_NAMESPACE}" --kubeconfig="${mgmt_kubecfg}" -o wide | grep "${dpu_workers[$i]}" | awk '{print $3}')
-    ## echo "check_pod_running is: ${check_pod_running}"
+    echo -e "✅ Found sriov test worker pod for DPU worker '${dpu_host_workers[$i]}': '${sriov_test_worker_pods[$i]}'"
 
     # check if the sriov test worker pod is running, if not Running, fail test ...
     if [ "$(oc get pod "${sriov_test_worker_pods[$i]}" -n "${SANITY_TESTS_WORKLOAD_NAMESPACE}" --kubeconfig="${mgmt_kubecfg}" -o jsonpath='{.status.phase}')" != "Running" ]; then
-    ## if [ "${check_pod_running}" != "Running" ]; then
       echo -e "❌ Test pod '${sriov_test_worker_pods[$i]}' is not running, Exiting script..."
       exit 1
     else 
@@ -455,13 +466,13 @@ for i in "${!dpu_workers[@]}"; do
     fi
   fi
 
-  echo -e "\nFinding sriov_test_workers_pods_hostnetwork name for dpu_workers array index $i '${dpu_workers[$i]}' to ping doca-hbn pod name '${doca_hbn_worker_pods[$i]}'"
-  sriov_test_worker_pods_hostnetwork[$i]=$(oc get pods -n "${SANITY_TESTS_WORKLOAD_NAMESPACE}" --kubeconfig="${mgmt_kubecfg}" -o wide | grep "${dpu_workers[$i]}" | awk '{print $1}' | grep hostnetwork)
+  echo -e "\nFinding sriov_test_workers_pods_hostnetwork name for dpu_host_workers array index $i '${dpu_host_workers[$i]}' to ping doca-hbn pod name '${doca_hbn_worker_pods[$i]}'"
+  sriov_test_worker_pods_hostnetwork[$i]=$(oc get pods -n "${SANITY_TESTS_WORKLOAD_NAMESPACE}" --kubeconfig="${mgmt_kubecfg}" -o wide | grep "${dpu_host_workers[$i]}" | awk '{print $1}' | grep hostnetwork)
   if [ -z "${sriov_test_worker_pods_hostnetwork[$i]}" ]; then
-    echo -e "❌ Failed to find sriov test worker hostnetwork pod for DPU worker '${dpu_workers[$i]}'. Exiting script..."
+    echo -e "❌ Failed to find sriov test worker hostnetwork pod for DPU worker '${dpu_host_workers[$i]}'. Exiting script..."
     exit 1
   else
-    echo -e "✅ Found sriov test worker hostnetwork pod for DPU worker '${dpu_workers[$i]}': '${sriov_test_worker_pods_hostnetwork[$i]}'"
+    echo -e "✅ Found sriov test worker hostnetwork pod for DPU worker '${dpu_host_workers[$i]}': '${sriov_test_worker_pods_hostnetwork[$i]}'"
     # check if the sriov test worker hostnetwork pod is running, if not Running, fail test ...
     if [ "$(oc get pod "${sriov_test_worker_pods_hostnetwork[$i]}" -n "${SANITY_TESTS_WORKLOAD_NAMESPACE}" --kubeconfig="${mgmt_kubecfg}" -o jsonpath='{.status.phase}')" != "Running" ]; then
       echo -e "❌ Test pod '${sriov_test_worker_pods_hostnetwork[$i]}' is not running, Exiting script..."
@@ -471,11 +482,11 @@ for i in "${!dpu_workers[@]}"; do
     fi
   fi
 
-  echo -e "\nList of interfaces that are up on doca-hbn pod '${doca_hbn_worker_pods[$i]}' for DPU worker '${dpu_workers[$i]}':"
+  echo -e "\nList of interfaces that are up on doca-hbn pod '${doca_hbn_worker_pods[$i]}' for DPU host worker '${dpu_host_workers[$i]}':"
   oc exec "${doca_hbn_worker_pods[$i]}" -n "${dpf_operator_namespace}"  --kubeconfig="${hosted_kubecfg}" -c doca-hbn -- ip -4 -o a
 
   doca_hbn_worker_pod_ip[$i]=$(oc exec "${doca_hbn_worker_pods[$i]}" -n "${dpf_operator_namespace}"  --kubeconfig="${hosted_kubecfg}" -c doca-hbn -- ip a show pf2dpu2_if | grep "inet " | awk '{print $2}' | cut -d'/' -f1)
-  echo -e "doca-hbn pod ip address for worker '${dpu_workers[$i]}' is: '${doca_hbn_worker_pod_ip[$i]}'"
+  echo -e "doca-hbn pod ip address for DPU worker '${dpu_workers[$i]}' is: '${doca_hbn_worker_pod_ip[$i]}'"
 
   # Test pings from sriov test-worker pod on worker node i:
   testcase_title="Test pings mtu 1490 from sriov worker test pod '${sriov_test_worker_pods[$i]}' to doca-hbn pod ip '${doca_hbn_worker_pod_ip[$i]}' on DPU worker '${dpu_workers[$i]}'"
@@ -491,11 +502,11 @@ for i in "${!dpu_workers[@]}"; do
 
   #----------  ping google.com on worker node i
   # Test pings from sriov test-worker pod on worker node i to 8.8.8.8 google.com:
-  testcase_title="Test pings from sriov worker test pod '${sriov_test_worker_pods[$i]}' to 8.8.8.8 google.com on DPU worker '${dpu_workers[$i]}'"
+  testcase_title="Test pings from sriov worker test pod '${sriov_test_worker_pods[$i]}' to 8.8.8.8 google.com on DPU host worker '${dpu_host_workers[$i]}'"
   ping_mtu_test "$testcase_title" "${sriov_test_worker_pods[$i]}" "${SANITY_TESTS_WORKLOAD_NAMESPACE}" "${mgmt_kubecfg}" "${SANITY_TESTS_PING_COUNT}" normal "8.8.8.8"
 
   # Test pings from sriov test-worker hostnetwork pod on worker node i to 8.8.8.8 google.com:
-  testcase_title="Test pings from sriov worker test pod on hostnetwork '${sriov_test_worker_pods_hostnetwork[$i]}' to 8.8.8.8 google.com on DPU worker '${dpu_workers[$i]}'"
+  testcase_title="Test pings from sriov worker test pod on hostnetwork '${sriov_test_worker_pods_hostnetwork[$i]}' to 8.8.8.8 google.com on DPU host worker '${dpu_host_workers[$i]}'"
   ping_mtu_test "$testcase_title" "${sriov_test_worker_pods_hostnetwork[$i]}" "${SANITY_TESTS_WORKLOAD_NAMESPACE}" "${mgmt_kubecfg}" "${SANITY_TESTS_PING_COUNT}" "normal" "8.8.8.8"
 
 done


### PR DESCRIPTION
Now that worker node names on management clusters are not necessarily using an FQDN of the baremetal server, we need to change the parsing to detect them.  This commit fixes that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Script now discovers and tracks DPU host worker nodes in the management cluster.
  * Introduces readiness validation for DPU host workers and fails fast if none are ready.

* **Improvements**
  * Test execution and pod interactions updated to operate in host-worker context.
  * Messaging and logs standardized to reference DPU host workers consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->