### PR TITLE
Fix v4.19 catalog source conditional deployment

### DIFF
--- a/scripts/manifests.sh
+++ b/scripts/manifests.sh
@@ -134,8 +134,13 @@ function prepare_cluster_manifests() {
         "99-worker-bridge.yaml"
     )
 
-    # Always exclude v4.19-specific CatalogSource (no longer needed with LVMS)
-    excluded_files+=("4.19-cataloguesource.yaml")
+    # Only exclude v4.19 catalog source if the workaround is not enabled
+    # USE_V419_WORKAROUND is INDEPENDENT of STORAGE_TYPE - it controls OLM catalog
+    # for all operators (NFD, SR-IOV, LSO, ODF, etc.) on OpenShift versions where
+    # these operators aren't available in the standard redhat-operators catalog
+    if [ "${USE_V419_WORKAROUND}" != "true" ]; then
+        excluded_files+=("4.19-cataloguesource.yaml")
+    fi
 
     # Copy all manifests except excluded files using utility function
     copy_manifests_with_exclusions "$MANIFESTS_DIR/cluster-installation" "$GENERATED_DIR" "${excluded_files[@]}"


### PR DESCRIPTION
Fixes v4.19 catalog source conditional deployment functionality.

## Problem
When USE_V419_WORKAROUND=true, operators were configured to use redhat-operators-v419 catalog, but the CatalogSource was always excluded from cluster manifests.

## Solution
Restore conditional logic to only exclude 4.19-cataloguesource.yaml when USE_V419_WORKAROUND=false.

## Testing
✅ Complete SNO deployment with HyperShift and DPF successfully tested
✅ ETCD correctly uses LVM storage (lvms-vg1)
✅ v4.19 catalog (redhat-operators-v419) correctly deployed  
✅ DPF deployment completed successfully

## Changes
- scripts/manifests.sh: Add conditional logic for v4.19 catalog source inclusion

Single commit with only the needed catalog fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved cluster manifest preparation to properly respect configuration flags for catalog source handling, ensuring correct deployment behavior across different environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->