### PR TITLE
Fix worker name detection and netshoot image from quay.io

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,9 @@
+approvers:
+- szigmon
+- tsorya
+- wabouhamad
+options: {}
+reviewers:
+- szigmon
+- tsorya
+- wabouhamad

--- a/manifests/post-installation-manual/workload.yaml
+++ b/manifests/post-installation-manual/workload.yaml
@@ -64,7 +64,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
-        image: nicolaka/netshoot
+        image: quay.io/wabouham/ecosys-nvidia/nicolaka-netshoot:latest
         command: ["nc", "-kl", "5000"]
         ports:
         - containerPort: 5000
@@ -144,7 +144,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
-        image: nicolaka/netshoot
+        image: quay.io/wabouham/ecosys-nvidia/nicolaka-netshoot:latest
         command: ["nc", "-kl", "5000"]
         ports:
         - containerPort: 5000
@@ -225,7 +225,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
-        image: nicolaka/netshoot
+        image: quay.io/wabouham/ecosys-nvidia/nicolaka-netshoot:latest
         command: ["nc", "-kl", "5000"]
         ports:
         - containerPort: 5000


### PR DESCRIPTION
Updated the dpf-sanity-checks.sh script to handle detecting worker node names that are not FQDNs.

Updated the manifest workload.yaml to use the netshoot image from quay.io