### PR TITLE
isolating aicli tokens for users will be able to see the cluster in a…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ WORKER_SCRIPT := scripts/worker.sh
         add-worker-nodes worker-status approve-worker-csrs \
         deploy-csr-approver delete-csr-approver deploy-dpucluster-csr-approver delete-dpucluster-csr-approver \
         verify-deployment verify-workers verify-dpu-nodes verify-dpudeployment \
-        run-traffic-flow-tests tft-setup tft-cleanup tft-show-config tft-results \
+        run-traffic-flow-tests tft-setup tft-cleanup tft-show-config tft-results aicli-list \
         generate-env
 
 all: 
@@ -53,6 +53,9 @@ verify-files:
 clean:
 	@$(CLUSTER_SCRIPT) clean
 
+aicli-list:
+	@bash -c 'source scripts/env.sh && aicli list clusters'
+	
 delete-cluster:
 	@$(CLUSTER_SCRIPT) delete-cluster
 

--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -102,6 +102,9 @@ echo "YOUR_OFFLINE_TOKEN" > ~/.aicli/offlinetoken.txt
 chmod 600 ~/.aicli/offlinetoken.txt
 ```
 
+To use a different user's token (e.g. when running as root but using tokens under `/root/xyz`), set `AICLI_HOME` in your `.env` or environment (e.g. `export AICLI_HOME=/root/xyz`). The automation will use `$AICLI_HOME/.aicli/offlinetoken.txt` and will check that this file exists when `AICLI_HOME` is set.
+**When using `AICLI_HOME`, your `OPENSHIFT_PULL_SECRET` file must contain a pull secret for the same Red Hat account** as the offline token (otherwise the API returns "pull secret token does not match current user").
+
 ### NVIDIA NGC API Key
 
 1. Create account at [NVIDIA NGC](https://ngc.nvidia.com/)

--- a/scripts/cluster.sh
+++ b/scripts/cluster.sh
@@ -256,7 +256,9 @@ function check_create_cluster() {
 
     if ! aicli info cluster ${CLUSTER_NAME} >/dev/null 2>&1; then
         log "INFO" "Cluster ${CLUSTER_NAME} not found, creating..."
-
+        
+        ensure_ssh_key_in_home || return 1
+        
         if [ "$VM_COUNT" -eq 1 ]; then
             log "INFO" "Creating single-node cluster..."
             aicli create cluster \

--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -51,6 +51,20 @@ if [ -z "${MAKELEVEL:-}" ]; then
     validate_mtu
 fi
 
+# aicli uses HOME to find ~/.aicli/offlinetoken.txt. Default: $HOME. Override with AICLI_HOME (e.g. in .env).
+# When using AICLI_HOME, OPENSHIFT_PULL_SECRET must be a pull secret for the same Red Hat account as that token.
+AICLI_HOME=${AICLI_HOME:-$HOME}
+if [[ "$AICLI_HOME" != "$HOME" ]] && [[ ! -f "${AICLI_HOME}/.aicli/offlinetoken.txt" ]]; then
+    echo "Error: ${AICLI_HOME}/.aicli/offlinetoken.txt not found." >&2
+    exit 1
+fi
+export HOME="${AICLI_HOME}"
+if ! aicli list clusters &>/dev/null; then
+    echo "Error: aicli list clusters failed. Check token at ${AICLI_HOME}/.aicli/offlinetoken.txt and connectivity." >&2
+    exit 1
+fi
+
+
 # Directory Configuration
 MANIFESTS_DIR=${MANIFESTS_DIR:-"manifests"}
 GENERATED_DIR=${GENERATED_DIR:-"$MANIFESTS_DIR/generated"}

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -404,6 +404,17 @@ copy_manifests_with_exclusions() {
     return 0
 }
 
+function ensure_ssh_key_in_home() {
+    if [ ! -f "${SSH_KEY}" ]; then
+        log "ERROR" "SSH public key file not found: ${SSH_KEY}. Set SSH_KEY in .env and place your .pub key there."
+        return 1
+    fi
+    if [[ "${SSH_KEY}" != *.pub ]]; then
+        log "ERROR" "SSH_KEY must point to a .pub file, got: ${SSH_KEY}"
+        return 1
+    fi
+}
+
 # -----------------------------------------------------------------------------
 # Cleanup functions
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
aicli token directory (optional). aicli reads ~/.aicli/offlinetoken.txt from HOME.
Default: current user's HOME. Set to use another user's token (e.g. /root/sbx).
When set, scripts validate that AICLI_HOME/.aicli/offlinetoken.txt exists.
OPENSHIFT_PULL_SECRET must be for the same Red Hat account as that token.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `make aicli-list` command to list available clusters
  * Support for AICLI_HOME environment variable to configure alternative user tokens
  * SSH key validation now occurs before cluster creation

* **Documentation**
  * Updated getting-started guide with AICLI_HOME configuration instructions and requirements
<!-- end of auto-generated comment: release notes by coderabbit.ai -->