### PR TITLE
Remove unmanage-ovnk-interface NetworkManager config

### DIFF
--- a/manifests/cluster-installation/99-worker-bridge.yaml
+++ b/manifests/cluster-installation/99-worker-bridge.yaml
@@ -20,11 +20,6 @@ spec:
           mode: 0755
           overwrite: true
           path: /usr/local/bin/configure-p0-routing.sh
-        - contents:
-            source: data:text/plain;charset=utf-8;base64,W2tleWZpbGVdCnVubWFuYWdlZC1kZXZpY2VzPWludGVyZmFjZS1uYW1lOm92bi1rOHMtKg==
-          mode: 0644
-          overwrite: true
-          path: "/etc/NetworkManager/conf.d/unmanage-ovnk-interface.conf"
     systemd:
       units:
         - contents: |


### PR DESCRIPTION
The unmanage-ovnk-interface.conf entry that prevented NetworkManager from managing ovn-k8s-* interfaces is no longer needed.