### PR TITLE
drop cni installer from DPFOperatorConfig

### DIFF
--- a/manifests/dpf-installation/dpfoperatorconfig.yaml
+++ b/manifests/dpf-installation/dpfoperatorconfig.yaml
@@ -12,6 +12,10 @@ spec:
   #Openshift multus is used for DPU cluster 
   multus:
     disable: true
+  cniInstaller:
+    # CNI installer isn't relevant for the OpenShift use case.
+    # In 25.10 it does not support the RHCOS BFB.
+    disable: true
   overrides:
     kubernetesAPIServerVIP: api.<CLUSTER_NAME>.<BASE_DOMAIN>
     kubernetesAPIServerPort: 6443


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new configuration option allowing administrators to disable the CNI installer as needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->