### PR TITLE
NVIDIA-544: Add full deletion support for the DPF-HCP-Provisioner Operator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ WORKER_SCRIPT := scripts/worker.sh
         deploy-core-operator-sources setup-nfs-server deploy-metallb deploy-lso deploy-odf deploy-lvms prepare-nfs run-dpf-sanity \
         add-worker-nodes worker-status approve-worker-csrs \
         deploy-csr-approver delete-csr-approver deploy-dpucluster-csr-approver delete-dpucluster-csr-approver \
+        delete-dpf-hcp-provisioner-operator \
         verify-deployment verify-workers verify-dpu-nodes verify-dpudeployment \
         run-traffic-flow-tests tft-setup tft-cleanup tft-show-config tft-results
 
@@ -249,6 +250,10 @@ deploy-dpucluster-csr-approver:
 delete-dpucluster-csr-approver:
 	@$(DPF_SCRIPT) delete-dpucluster-csr-approver
 
+delete-dpf-hcp-provisioner-operator:
+	@echo "Deleting DPF HCP Provisioner Operator..."
+	@$(DPF_SCRIPT) delete-dpf-hcp-provisioner-operator
+
 # Verification targets
 verify-deployment:
 	@$(VERIFY_SCRIPT) verify-deployment
@@ -314,6 +319,7 @@ help:
 	@echo "  delete-csr-approver - Remove CSR auto-approver from host cluster"
 	@echo "  deploy-dpucluster-csr-approver - Deploy CSR auto-approver for DPUCluster (runs on host)"
 	@echo "  delete-dpucluster-csr-approver - Remove CSR auto-approver for DPUCluster"
+	@echo "  delete-dpf-hcp-provisioner-operator - Remove DPF HCP Provisioner Operator and related resources"
 	@echo ""
 	@echo "Verification:"
 	@echo "  verify-deployment     - Full verification: workers + DPU nodes + DPUDeployment"

--- a/scripts/dpf.sh
+++ b/scripts/dpf.sh
@@ -666,6 +666,66 @@ function delete_dpucluster_csr_approver() {
     log "INFO" "DPUCluster CSR auto-approver removed"
 }
 
+function delete_dpf_hcp_provisioner_operator() {
+    # Remove DPF HCP Provisioner Operator and all related resources
+    log "INFO" "Removing DPF HCP Provisioner Operator..."
+
+    get_kubeconfig
+
+    # Ensure helm is installed
+    ensure_helm_installed
+
+    # Delete DPFHCPProvisioner CR instances (if any exist)
+    log "INFO" "Deleting DPFHCPProvisioner custom resources..."
+    if oc get dpfhcpprovisioner -n "${CLUSTERS_NAMESPACE}" &>/dev/null 2>&1; then
+        if ! oc delete dpfhcpprovisioner --all -n "${CLUSTERS_NAMESPACE}" --ignore-not-found --timeout=600s; then
+            log "ERROR" "Failed to delete DPFHCPProvisioner CRs. Exiting..."
+            return 1
+        fi
+    else
+        log "INFO" "No DPFHCPProvisioner CRs found in ${CLUSTERS_NAMESPACE}"
+    fi
+
+    # Delete secrets created for DPFHCPProvisioner in clusters namespace
+    log "INFO" "Deleting DPFHCPProvisioner secrets from ${CLUSTERS_NAMESPACE}..."
+    oc delete secret -n "${CLUSTERS_NAMESPACE}" "${DPFHCPPROVISIONER_PULL_SECRET_NAME}" --ignore-not-found || {
+        log "WARN" "Failed to delete secret ${DPFHCPPROVISIONER_PULL_SECRET_NAME} - it may not exist or there may be permission issues"
+    }
+    oc delete secret -n "${CLUSTERS_NAMESPACE}" "${DPFHCPPROVISIONER_SSH_SECRET_NAME}" --ignore-not-found || {
+        log "WARN" "Failed to delete secret ${DPFHCPPROVISIONER_SSH_SECRET_NAME} - it may not exist or there may be permission issues"
+    }
+
+    # Uninstall helm release
+    log "INFO" "Uninstalling DPF HCP Provisioner Operator helm release..."
+    if helm list -n "${DPF_HCP_PROVISIONER_OPERATOR_NAMESPACE}" | grep -q "^dpf-hcp-provisioner-operator[[:space:]]"; then
+        helm uninstall dpf-hcp-provisioner-operator -n "${DPF_HCP_PROVISIONER_OPERATOR_NAMESPACE}" --wait || {
+            log "WARN" "Failed to uninstall helm release dpf-hcp-provisioner-operator"
+        }
+        log "INFO" "Helm release uninstalled successfully"
+    else
+        log "INFO" "Helm release dpf-hcp-provisioner-operator not found"
+    fi
+
+    # Delete the CRD
+    log "INFO" "Deleting DPFHCPProvisioner CRD..."
+    oc delete crd dpfhcpprovisioners.provisioning.dpu.hcp.io --ignore-not-found --timeout=600s || {
+        log "WARN" "Failed to delete DPFHCPProvisioner CRD, it may have finalizers or dependent resources"
+    }
+
+    # Delete the operator namespace (helm uninstall does not delete namespaces)
+    log "INFO" "Deleting DPF HCP Provisioner Operator namespace ${DPF_HCP_PROVISIONER_OPERATOR_NAMESPACE}..."
+    if oc get namespace "${DPF_HCP_PROVISIONER_OPERATOR_NAMESPACE}" &>/dev/null 2>&1; then
+        oc delete namespace "${DPF_HCP_PROVISIONER_OPERATOR_NAMESPACE}" --ignore-not-found --timeout=180s || {
+            log "WARN" "Failed to delete namespace ${DPF_HCP_PROVISIONER_OPERATOR_NAMESPACE}, it may have finalizers or remaining resources"
+        }
+    else
+        log "INFO" "Namespace ${DPF_HCP_PROVISIONER_OPERATOR_NAMESPACE} not found"
+    fi
+
+    log "INFO" "DPF HCP Provisioner Operator removal complete"
+    log "INFO" "Note: The ${CLUSTERS_NAMESPACE} namespace was not deleted as it may contain other resources"
+}
+
 # -----------------------------------------------------------------------------
 # Command dispatcher
 # -----------------------------------------------------------------------------
@@ -696,6 +756,9 @@ function main() {
             deploy-dpf-hcp-provisioner-operator)
                 deploy_dpf_hcp_provisioner_operator
                 ;;
+            delete-dpf-hcp-provisioner-operator)
+                delete_dpf_hcp_provisioner_operator
+                ;;
             create-dpfhcpprovisioner-secrets)
                 create_dpfhcpprovisioner_secrets
                 ;;
@@ -713,7 +776,7 @@ function main() {
                 ;;
             *)
                 log [INFO] "Unknown command: $command"
-                log [INFO] "Available commands: deploy-nfd, deploy-metallb, deploy-argocd, deploy-maintenance-operator, apply-dpf, deploy-hypershift, deploy-dpucluster-csr-approver, delete-dpucluster-csr-approver, deploy-dpf-hcp-provisioner-operator, create-dpfhcpprovisioner-secrets, create-dpfhcpprovisioner-cr"
+                log [INFO] "Available commands: deploy-nfd, deploy-metallb, deploy-argocd, deploy-maintenance-operator, apply-dpf, deploy-hypershift, deploy-dpucluster-csr-approver, delete-dpucluster-csr-approver, deploy-dpf-hcp-provisioner-operator, delete-dpf-hcp-provisioner-operator, create-dpfhcpprovisioner-secrets, create-dpfhcpprovisioner-cr"
                 exit 1
                 ;;
         esac


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a command to fully remove the DPF HCP Provisioner Operator and its related resources (Helm release, custom resources, secrets, CRDs, and operator namespace).
  * Command is integrated into the project's workflow so it can be invoked as a public target.

* **Documentation**
  * Made the new delete command discoverable via the CLI Make target and updated help output to include it.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->