### PR TITLE
Revert "Remove unmanage-ovnk-interface NetworkManager config"

### DIFF
--- a/manifests/cluster-installation/99-worker-bridge.yaml
+++ b/manifests/cluster-installation/99-worker-bridge.yaml
@@ -20,6 +20,11 @@ spec:
           mode: 0755
           overwrite: true
           path: /usr/local/bin/configure-p0-routing.sh
+        - contents:
+            source: data:text/plain;charset=utf-8;base64,W2tleWZpbGVdCnVubWFuYWdlZC1kZXZpY2VzPWludGVyZmFjZS1uYW1lOm92bi1rOHMtKg==
+          mode: 0644
+          overwrite: true
+          path: "/etc/NetworkManager/conf.d/unmanage-ovnk-interface.conf"
     systemd:
       units:
         - contents: |


### PR DESCRIPTION
We need this one as it totally disables NM management over this interface
Revert "Remove unmanage-ovnk-interface NetworkManager config"

This reverts commit 15c6de60a936719899051b5b570d322fe7f481bd.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced worker node networking configuration with improved NetworkManager integration and routing capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->