### PR TITLE
fix: max prefix feature for dhcp

### DIFF
--- a/scripts/cluster.sh
+++ b/scripts/cluster.sh
@@ -184,7 +184,9 @@ function set_node_nmstate() {
             VM_NAME="${VM_PREFIX}${i}"
             NODE_IP="${IP_ARRAY[$((i-1))]}"
 
-            if ! UNIQUE_MAC=$(generate_mac_from_machine_id "$VM_NAME"); then
+            if [ -n "$MAC_PREFIX" ]; then
+                UNIQUE_MAC="52:54:00:${MAC_PREFIX}:$(printf '%02x' "$i")"
+            elif ! UNIQUE_MAC=$(generate_mac_from_machine_id "$VM_NAME"); then
                 log "ERROR" "Failed to generate MAC for $VM_NAME"
                 return 1
             fi
@@ -222,7 +224,9 @@ EOF
     for i in $(seq 1 "$VM_COUNT"); do
         VM_NAME="${VM_PREFIX}${i}"
 
-        if ! UNIQUE_MAC=$(generate_mac_from_machine_id "$VM_NAME"); then
+        if [ -n "$MAC_PREFIX" ]; then
+            UNIQUE_MAC="52:54:00:${MAC_PREFIX}:$(printf '%02x' "$i")"
+        elif ! UNIQUE_MAC=$(generate_mac_from_machine_id "$VM_NAME"); then
             log "ERROR" "Failed to generate MAC for $VM_NAME"
             return 1
         fi

--- a/scripts/vm.sh
+++ b/scripts/vm.sh
@@ -74,7 +74,11 @@ function create_vms() {
         echo "$mac"
     }
 
-    if [ -f "$STATIC_NET_FILE" ]; then
+    if [ "${VM_STATIC_IP}" = "true" ]; then
+        if [ ! -f "$STATIC_NET_FILE" ]; then
+            log "ERROR" "VM_STATIC_IP=true but static network file not found: $STATIC_NET_FILE"
+            exit 1
+        fi
         log "INFO" "Found static_net.yaml. Creating VMs based on file content."
         # parse the YAML into a JSON string
         VMS_CONFIG=$(python3 -c 'import yaml, json; print(json.dumps(yaml.safe_load(open("'"$STATIC_NET_FILE"'"))["static_network_config"]))')


### PR DESCRIPTION
this fixes an issue caused by the static IP implementation

this enables the custom mac prefix path to work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable MAC address prefix option for network device setup, with a deterministic fallback when unset.
* **Chores**
  * Static-network VM creation now requires an explicit static-IP flag and enforces presence of the static network configuration before proceeding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->