### PR TITLE
Move BMH flow to earlier in installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ all:
 	@mkdir -p logs
 	@bash -o pipefail -c '$(MAKE) _all 2>&1 | tee "logs/make_all_$(shell date +%Y%m%d_%H%M%S).log"'
 
-_all: verify-files check-cluster create-vms prepare-manifests cluster-install update-etc-hosts kubeconfig deploy-dpf prepare-dpu-files deploy-dpu-services enable-ovn-injector add-worker-nodes
+_all: verify-files check-cluster create-vms prepare-manifests cluster-install update-etc-hosts kubeconfig add-worker-nodes deploy-dpf prepare-dpu-files deploy-dpu-services enable-ovn-injector
 	@echo ""
 	@echo "================================================================================"
 	@echo "✅ DPF Installation Complete!"

--- a/scripts/worker.sh
+++ b/scripts/worker.sh
@@ -82,9 +82,9 @@ provision_all_workers() {
             "<BMC_IP>" "$bmc_ip" \
             "<ROOT_DEVICE>" "$root_dev"
 
-        # Apply manifests
-        apply_manifest "${WORKER_GENERATED_DIR}/${name}-bmc-secret.yaml" false
-        apply_manifest "${WORKER_GENERATED_DIR}/${name}-bmh.yaml" false
+        # Apply manifests (retry for transient API/controller or network failures)
+        retry 5 10 apply_manifest "${WORKER_GENERATED_DIR}/${name}-bmc-secret.yaml" false
+        retry 5 10 apply_manifest "${WORKER_GENERATED_DIR}/${name}-bmh.yaml" false
         log "INFO" "BMH $name created"
     done
 


### PR DESCRIPTION
Move the creation of BMH to earlier in the process. This should speed up the installation of the worker nodes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated build execution flow; worker node provisioning no longer runs automatically during default build process.

* **Bug Fixes**
  * Enhanced resilience of worker manifest deployments by adding automatic retry logic to handle transient failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->