### PR TITLE
fix: BFB registry MutatingAdmissionPolicy

### DIFF
--- a/manifests/cluster-installation/openshift/99_feature-gate.yaml
+++ b/manifests/cluster-installation/openshift/99_feature-gate.yaml
@@ -1,0 +1,9 @@
+apiVersion: config.openshift.io/v1
+kind: FeatureGate
+metadata:
+  name: cluster
+spec:
+  featureSet: CustomNoUpgrade
+  customNoUpgrade:
+    enabled:
+    - MutatingAdmissionPolicy

--- a/manifests/dpf-installation/bfb-registry-privileged-policy.yaml
+++ b/manifests/dpf-installation/bfb-registry-privileged-policy.yaml
@@ -1,0 +1,43 @@
+apiVersion: admissionregistration.k8s.io/v1alpha1
+kind: MutatingAdmissionPolicy
+metadata:
+  name: mutate-bfb-registry-privileged
+spec:
+  failurePolicy: Fail
+  reinvocationPolicy: Never
+  matchConstraints:
+    resourceRules:
+    - apiGroups: [""]
+      apiVersions: ["v1"]
+      operations: ["CREATE"]
+      resources: ["pods"]
+  matchConditions:
+  - name: is-bfb-registry-pod
+    expression: >-
+      object.metadata.namespace == "dpf-operator-system" &&
+      has(object.metadata.labels) &&
+      "dpu.nvidia.com/component" in object.metadata.labels &&
+      object.metadata.labels["dpu.nvidia.com/component"] == "bfb-registry"
+  mutations:
+  - patchType: ApplyConfiguration
+    applyConfiguration:
+      expression: >-
+        Object{
+          spec: Object.spec{
+            containers: [
+              Object.spec.containers{
+                name: object.spec.containers[0].name,
+                securityContext: Object.spec.containers.securityContext{
+                  privileged: true
+                }
+              }
+            ]
+          }
+        }
+---
+apiVersion: admissionregistration.k8s.io/v1alpha1
+kind: MutatingAdmissionPolicyBinding
+metadata:
+  name: mutate-bfb-registry-privileged-binding
+spec:
+  policyName: mutate-bfb-registry-privileged

--- a/scripts/enable-ovn-injector.sh
+++ b/scripts/enable-ovn-injector.sh
@@ -35,6 +35,7 @@ helm template -n ${OVNK_NAMESPACE} ovn-kubernetes \
     --set ovn-kubernetes-resource-injector.resourceName="${INJECTOR_RESOURCE_NAME}" \
     --set ovn-kubernetes-resource-injector.prioritizeOffloading=false \
     --set ovn-kubernetes-resource-injector.controllerManager.hostNetwork=true \
+    --set "ovn-kubernetes-resource-injector.controllerManager.webhook.args={--leader-elect,--metrics-bind-address=:29091}" \
     --set nodeWithDPUManifests.enabled=false \
     --set nodeWithoutDPUManifests.enabled=false \
     --set dpuManifests.enabled=false \

--- a/scripts/manifests.sh
+++ b/scripts/manifests.sh
@@ -96,8 +96,8 @@ function prepare_cluster_manifests() {
         log [INFO] "Installing manifests to cluster via AICLI..."
         aicli create manifests --dir "$GENERATED_DIR" "$CLUSTER_NAME"
 
-        # Upload openshift folder manifests to the openshift folder
-        # This is needed to override built-in OpenShift manifests at install time
+        # Upload openshift folder manifests (e.g., FeatureGate) to the openshift folder
+        # This is needed to override built-in OpenShift manifests like 99_feature-gate.yaml
         local openshift_manifests_dir="$MANIFESTS_DIR/cluster-installation/openshift"
         if [ -d "$openshift_manifests_dir" ] && [ "$(ls -A "$openshift_manifests_dir" 2>/dev/null)" ]; then
             log [INFO] "Installing openshift folder manifests (to override built-in manifests)..."

--- a/scripts/post-install.sh
+++ b/scripts/post-install.sh
@@ -347,36 +347,6 @@ function apply_post_installation() {
     fi
     
     log [INFO] "Post-installation manifest application completed successfully"
-
-    patch_bfb_registry
-}
-
-function patch_bfb_registry() {
-    # The bfb-registry is a standalone pod (not a Deployment) that serves BFB files via nginx.
-    # On OpenShift, SELinux blocks non-privileged containers from reading HostPath files written
-    # by other pods. The bfb-registry needs privileged: true to read files in /bfb/bfcfg/.
-    # Since standalone pod securityContext is immutable, we must replace the pod.
-    log [INFO] "Waiting for bfb-registry pod..."
-    if ! retry 30 10 oc get pod -n dpf-operator-system bfb-registry &>/dev/null; then
-        log [WARN] "bfb-registry pod not found, skipping SELinux privilege patch"
-        return 0
-    fi
-
-    log [INFO] "Replacing bfb-registry pod with privileged securityContext for OpenShift SELinux compatibility..."
-    if ! oc get pod bfb-registry -n dpf-operator-system -o json | \
-        python3 -c "
-import json, sys
-pod = json.load(sys.stdin)
-for key in ['resourceVersion','uid','creationTimestamp','managedFields']:
-    pod['metadata'].pop(key, None)
-pod.pop('status', None)
-pod['spec']['containers'][0]['securityContext']['privileged'] = True
-json.dump(pod, sys.stdout)
-" | oc replace --force -f -; then
-        log [ERROR] "Failed to replace bfb-registry pod with privileged securityContext"
-        return 1
-    fi
-    log [INFO] "bfb-registry pod replaced successfully"
 }
 
 function redeploy() {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added cluster FeatureGate to enable a custom feature set
  * Introduced automated admission policies to enforce pod security for specific workloads

* **Enhancements**
  * Webhook now uses leader election and exposes metrics

* **Documentation**
  * Clarified manifest upload guidance and example for OpenShift overrides

* **Refactor**
  * Removed post-install manual privileged-patch step; privileges handled via admission policies instead
<!-- end of auto-generated comment: release notes by coderabbit.ai -->