### PR TITLE
NVIDIA-654: Enable enableDynamicBFCFGTemplates in DpfOperatorConfig to allow DPF to identify bf.cfg CMs for specific DPUClusters using annotations

### DIFF
--- a/manifests/dpf-installation/dpfoperatorconfig.yaml
+++ b/manifests/dpf-installation/dpfoperatorconfig.yaml
@@ -26,6 +26,7 @@ spec:
     # When using OpenShift Multus (default), Flannel needs to install CNI config
     flannelSkipCNIConfigInstallation: false
   provisioningController:
+    enableDynamicBFCFGTemplates: true
     hostAgentDNSPolicy: Default
     dmsTimeout: 900
     registry:


### PR DESCRIPTION
With the recent changes in DPF, users can now set `enableDynamicBFCFGTemplates: true` in the **DpfOperatorConfig CR**. When enabled, the DPF provisioning controller discovers the relevant ConfigMaps (containing the ignition consumed by DPF) by matching labels such as **BFB name/namespace**, **DPUCluster name/namespace**, and **DPUFlavor name/namespace**.

As a result, we need to update our automation accordingly. However, this PR should be merged only after the corresponding [PR](https://github.com/rh-ecosystem-edge/dpf-hcp-provisioner-operator/pull/59) in **dpf-hcp-provisioner** is merged, since it generates the bf.cfg with the appropriate annotations needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled dynamic template generation through the provisioning controller, allowing automatic configuration template creation based on system requirements, providing greater flexibility in system provisioning and reducing manual configuration overhead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->