### PR TITLE
Add SRIOV_DP_RESOURCE_PREFIX substitution to NodeSRIOVDevicePluginConfig

### DIFF
--- a/manifests/post-installation/nodesriovdevicepluginconfig.yaml
+++ b/manifests/post-installation/nodesriovdevicepluginconfig.yaml
@@ -7,12 +7,14 @@ spec:
   devicePluginResources:
     - name: <SRIOV_DP_CONFIG_NAME>-mgmt
       type: vf
+      resourcePrefix: <SRIOV_DP_RESOURCE_PREFIX>
       ranges:
         - pfIndex: 0
           start: 1
           end: 1
     - name: <SRIOV_DP_CONFIG_NAME>
       type: vf
+      resourcePrefix: <SRIOV_DP_RESOURCE_PREFIX>
       options:
         isRdma: true
       ranges:

--- a/scripts/post-install.sh
+++ b/scripts/post-install.sh
@@ -263,7 +263,8 @@ function prepare_post_installation() {
         "${POST_INSTALL_DIR}/nodesriovdevicepluginconfig.yaml" \
         "${GENERATED_POST_INSTALL_DIR}/nodesriovdevicepluginconfig.yaml" \
         "<SRIOV_DP_CONFIG_NAME>" "${SRIOV_DP_CONFIG_NAME}" \
-        "<NUM_VFS_END>" "${vf_range_end}"
+        "<NUM_VFS_END>" "${vf_range_end}" \
+        "<SRIOV_DP_RESOURCE_PREFIX>" "${SRIOV_DP_RESOURCE_PREFIX}"
 
     # Copy remaining manifests using utility function (exclude special files)
     copy_manifests_with_exclusions "${POST_INSTALL_DIR}" "${GENERATED_POST_INSTALL_DIR}" "${SPECIAL_FILES[@]}"


### PR DESCRIPTION
The resourcePrefix field in nodesriovdevicepluginconfig.yaml was not being substituted during post-install manifest generation. Add the placeholder and wire it through post-install.sh using the existing SRIOV_DP_RESOURCE_PREFIX env variable (default: openshift.io).

Made-with: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added resource prefix parameter to SR-IOV device plugin resource configurations.

* **Chores**
  * Updated post-installation configuration process to properly substitute the resource prefix parameter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->