### PR TITLE
fix: bump openshift version in defaults

### DIFF
--- a/ci/env.defaults
+++ b/ci/env.defaults
@@ -6,7 +6,7 @@
 # Syntax: ${VAR:-default} means "use default if VAR is unset or empty"
 
 # Cluster Configuration
-OPENSHIFT_VERSION=${OPENSHIFT_VERSION:-4.21.0}
+OPENSHIFT_VERSION=${OPENSHIFT_VERSION:-4.21.1}
 USE_V419_WORKAROUND=${USE_V419_WORKAROUND:-false}
 
 # Bridge Configuration


### PR DESCRIPTION
bump openshift version to one supported by the HCP provisioner

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated OpenShift version to 4.21.1

<!-- end of auto-generated comment: release notes by coderabbit.ai -->