### PR TITLE
No need to provide API and IGRESS vips in case of sno

### DIFF
--- a/ci/env.required
+++ b/ci/env.required
@@ -11,9 +11,12 @@
 : ${BASE_DOMAIN:?BASE_DOMAIN must be set}
 
 # Network / DPU
-: ${API_VIP:?API_VIP must be set}
-: ${INGRESS_VIP:?INGRESS_VIP must be set}
+if [ "${VM_COUNT:-3}" -gt 1 ]; then
+    : ${API_VIP:?API_VIP must be set (required for multi-node clusters)}
+    : ${INGRESS_VIP:?INGRESS_VIP must be set (required for multi-node clusters)}
+fi
 : ${DPU_HOST_CIDR:?DPU_HOST_CIDR must be set (e.g. 10.0.110.0/24)}
 
 # BFB
 : ${BFB_URL:?BFB_URL must be set}
+


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Made API and Ingress VIP validation conditional—now only required for multi-node deployments. Single-node cluster configurations can proceed without these settings, reducing unnecessary configuration requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->