### PR TITLE
NO-ISSUE: Disable BlueField-OCP validation when deploying the dpf-hcp-provisioner operator

### DIFF
--- a/scripts/dpf.sh
+++ b/scripts/dpf.sh
@@ -202,7 +202,8 @@ function deploy_dpf_hcp_provisioner_operator() {
         --create-namespace \
         ${version_flag} \
         --set image.repository=${DPF_HCP_PROVISIONER_OPERATOR_IMAGE_REPO} \
-        --set image.tag=${DPF_HCP_PROVISIONER_OPERATOR_IMAGE_TAG}; then
+        --set image.tag=${DPF_HCP_PROVISIONER_OPERATOR_IMAGE_TAG} \
+        --set provisionerConfig.enableBlueFieldValidation=false; then
 
         log [INFO] "Helm release 'dpf-hcp-provisioner-operator' deployed successfully"
         log [INFO] "DPF HCP Provisioner Operator deployment initiated. Use 'oc get pods -n ${DPF_HCP_PROVISIONER_OPERATOR_NAMESPACE}' to monitor progress."


### PR DESCRIPTION
Currently, if a developer wants to use `machineOSURL` in the `dpfhcpprovisioner` CR - pointing to the repository that hosts BlueField container images - but there is no matching BlueField container image for the specified `ocp_version`, the BlueField OCP validation fails causing the CR to remain in the "failed" phase. This happens even though the intention is to rely on the provided `machineOSURL` rather than an image tied to that OCP version.
Therefore, we decided to disable this validation, since the automation already uses `machineOSURL` by default.

For this to work, [this](https://github.com/rh-ecosystem-edge/dpf-hcp-provisioner-operator/pull/63) bug fix in the operator must be merged first.

cc @tsorya 

--
**Before these changes:**
```
[root@nvd-srv-44 openshift-dpf]# oc get dpfhcpprovisionerconfigs.provisioning.dpu.hcp.io -A
NAME      BLUEFIELDREPO               VALIDATIONENABLED   AGE
default   quay.io/eelgaev/rhcos-bfb   true                6s
```

```
[root@nvd-srv-44 openshift-dpf]# oc get dpfhcpprovisioner -A -o yaml
apiVersion: v1                                      
items:                                                                                                  
- apiVersion: provisioning.dpu.hcp.io/v1alpha1
  kind: DPFHCPProvisioner                           
...
  spec:                                                                                                 
...
    machineOSURL: quay.io/eelgaev/rhcos-bfb:4.21.1
    ocpReleaseImage: quay.io/openshift-release-dev/ocp-release:4.22.0-ec.3-multi
  status:
    conditions:
...
    - lastTransitionTime: "2026-03-24T09:47:24Z"
      message: BlueField image not found for OCP version 4.22.0-ec.3 in repository
        quay.io/eelgaev/rhcos-bfb
      observedGeneration: 1
      reason: VersionNotFound
      status: "False"
      type: BlueFieldImageResolved
...
    phase: Failed
```

**After:**

```
[root@nvd-srv-44 openshift-dpf]# oc get dpfhcpprovisionerconfigs.provisioning.dpu.hcp.io -A
NAME      BLUEFIELDREPO               VALIDATIONENABLED   AGE
default   quay.io/eelgaev/rhcos-bfb   false               7s
```

```
[root@nvd-srv-44 openshift-dpf]# oc get dpfhcpprovisioner -A -o yaml                                    
apiVersion: v1                                      
items:                                                                                                  
- apiVersion: provisioning.dpu.hcp.io/v1alpha1
  kind: DPFHCPProvisioner                           
 ...
  spec:                                                                                                 
...
    machineOSURL: quay.io/eelgaev/rhcos-bfb:4.21.1
    ocpReleaseImage: quay.io/openshift-release-dev/ocp-release:4.22.0-ec.3-multi
...
  status:
    conditions:
...
      message: BlueField image validation is disabled via operator config
      observedGeneration: 1
      reason: ValidationDisabled
      status: "True"
      type: BlueFieldImageResolved
    - lastTransitionTime: "2026-03-24T09:54:15Z"
...
    phase: Ready
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated provisioning operator deployment configuration with revised chart settings to modify validation behavior during installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->