### PR TITLE
BF-Bundle workaround

### DIFF
--- a/manifests/post-installation/bfb.yaml
+++ b/manifests/post-installation/bfb.yaml
@@ -7,3 +7,8 @@ metadata:
 spec:
   fileName: <BFB_FILENAME>
   url: <BFB_URL>
+  versions:
+    atf: 4.12.0-27-gd9bafc95f
+    bsp: 4.12.0.13754
+    doca: 3.1.0
+    uefi: 4.12.0-19-gdd4c9d8a10

--- a/manifests/post-installation/bfb.yaml
+++ b/manifests/post-installation/bfb.yaml
@@ -8,7 +8,7 @@ spec:
   fileName: <BFB_FILENAME>
   url: <BFB_URL>
   versions:
-    atf: 4.12.0-27-gd9bafc95f
-    bsp: 4.12.0.13754
-    doca: 3.1.0
-    uefi: 4.12.0-19-gdd4c9d8a10
+    atf: 4.13.1-0-g5fcb148df
+    bsp: 4.13.1.13827
+    doca: 3.2.0
+    uefi: 4.13.1-14-g8a01157b7f


### PR DESCRIPTION
Temporary workaround until we figure out a better way, or until DPF drops this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Pinned release versions for core components:
    * ATF → 4.13.1-0-g5fcb148df
    * BSP → 4.13.1.13827
    * DOCA → 3.2.0
    * UEFI → 4.13.1-14-g8a01157b7f
<!-- end of auto-generated comment: release notes by coderabbit.ai -->