### PR TITLE
Add --disable-openapi-validation to helm installs and exclude Package…

### DIFF
--- a/manifests/gitops-operator/argocd.yaml
+++ b/manifests/gitops-operator/argocd.yaml
@@ -5,6 +5,14 @@ metadata:
   name: argocd
   namespace: dpf-operator-system
 spec:
+  resourceExclusions: |
+    - apiGroups:
+      - packages.operators.coreos.com
+      kinds:
+      - PackageManifest
+      clusters:
+      - "*"
+
   nodePlacement:
     nodeSelector:
       node-role.kubernetes.io/control-plane: ""

--- a/scripts/dpf.sh
+++ b/scripts/dpf.sh
@@ -200,6 +200,7 @@ function deploy_dpf_hcp_provisioner_operator() {
         "${DPF_HCP_PROVISIONER_OPERATOR_CHART_URL}" \
         --namespace ${DPF_HCP_PROVISIONER_OPERATOR_NAMESPACE} \
         --create-namespace \
+        --disable-openapi-validation \
         ${version_flag} \
         --set image.repository=${DPF_HCP_PROVISIONER_OPERATOR_IMAGE_REPO} \
         --set image.tag=${DPF_HCP_PROVISIONER_OPERATOR_IMAGE_TAG}; then
@@ -498,6 +499,7 @@ function deploy_maintenance_operator() {
     helm upgrade --install maintenance-operator oci://ghcr.io/mellanox/maintenance-operator-chart \
         --namespace dpf-operator-system \
         --create-namespace \
+        --disable-openapi-validation \
         --version ${MAINTENANCE_OPERATOR_VERSION} \
         --values "${HELM_CHARTS_DIR}/maintenance-operator-values.yaml" \
         --wait
@@ -596,6 +598,7 @@ function apply_dpf() {
         ${HELM_ARGS} \
         --namespace dpf-operator-system \
         --create-namespace \
+        --disable-openapi-validation \
         --values "${HELM_CHARTS_DIR}/dpf-operator-values.yaml"; then
         
         log "INFO" "Helm release 'dpf-operator' deployed successfully"


### PR DESCRIPTION
…Manifest from ArgoCD

Adds --disable-openapi-validation flag to all three helm upgrade --install commands (dpf-hcp-provisioner-operator, maintenance-operator, dpf-operator) to avoid OpenAPI validation failures. Configures ArgoCD resource exclusions for PackageManifest resources to prevent sync issues.

Made-with: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated ArgoCD resource management configuration to exclude specific operator resources from synchronization
  * Disabled OpenAPI validation during Helm deployments for improved deployment compatibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->