### PR TITLE
fix: add workaround for SCC UID for in-cluster DPUServices

### DIFF
--- a/ci/env.defaults
+++ b/ci/env.defaults
@@ -21,7 +21,7 @@ GENERATED_POST_INSTALL_DIR=${GENERATED_POST_INSTALL_DIR:-manifests/generated/pos
 SSH_KEY=${SSH_KEY:-~/.ssh/id_rsa.pub}
 
 # DPF Configuration
-DPF_VERSION=${DPF_VERSION:-26.4.0-f314aa17}
+DPF_VERSION=${DPF_VERSION:-26.4.0-47183a84}
 DPF_HELM_REPO_URL=${DPF_HELM_REPO_URL:-oci://ghcr.io/killianmuldoon/doca-platform/charts}
 OVN_CHART_URL=${OVN_CHART_URL:-oci://ghcr.io/mellanox/charts}
 OVN_TEMPLATE_CHART_URL=${OVN_TEMPLATE_CHART_URL:-oci://ghcr.io/mellanox/charts}

--- a/manifests/dpf-installation/in-cluster-scc-policy.yaml
+++ b/manifests/dpf-installation/in-cluster-scc-policy.yaml
@@ -1,0 +1,38 @@
+apiVersion: admissionregistration.k8s.io/v1alpha1
+kind: MutatingAdmissionPolicy
+metadata:
+  name: mutate-in-cluster-pod-security
+spec:
+  failurePolicy: Fail
+  reinvocationPolicy: Never
+  matchConstraints:
+    resourceRules:
+    - apiGroups: [""]
+      apiVersions: ["v1"]
+      operations: ["CREATE"]
+      resources: ["pods"]
+  matchConditions:
+  - name: is-target-pod
+    expression: >-
+      object.metadata.namespace == "dpf-operator-system" &&
+      has(object.metadata.generateName) &&
+      (object.metadata.generateName.startsWith("in-cluster-kube-state-metrics-") ||
+       object.metadata.generateName.startsWith("in-cluster-nvidia-k8s-ipam-") ||
+       object.metadata.generateName.startsWith("in-cluster-servicechainset-controller-"))
+  mutations:
+  - patchType: JSONPatch
+    jsonPatch:
+      expression: >-
+        (has(object.spec.securityContext) && has(object.spec.securityContext.runAsUser) ?
+          [JSONPatch{op: "remove", path: "/spec/securityContext/runAsUser"}] : [])
+        + (has(object.spec.securityContext) && has(object.spec.securityContext.fsGroup) ?
+          [JSONPatch{op: "remove", path: "/spec/securityContext/fsGroup"}] : [])
+        + (has(object.spec.containers[0].securityContext) && has(object.spec.containers[0].securityContext.runAsUser) ?
+          [JSONPatch{op: "remove", path: "/spec/containers/0/securityContext/runAsUser"}] : [])
+---
+apiVersion: admissionregistration.k8s.io/v1alpha1
+kind: MutatingAdmissionPolicyBinding
+metadata:
+  name: mutate-in-cluster-pod-security-binding
+spec:
+  policyName: mutate-in-cluster-pod-security


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default DPF build version
  * Added pod security configuration for cluster deployments in operator namespace

<!-- end of auto-generated comment: release notes by coderabbit.ai -->