### PR TITLE
Updates to scripts to redact sensitive info in logs

### DIFF
--- a/scripts/dpf-sanity-checks.sh
+++ b/scripts/dpf-sanity-checks.sh
@@ -72,9 +72,6 @@ else
   exit 1
 fi
 
-echo -e "\nContents of hosted cluster kubeconfig file '${hosted_kubecfg}':"
-cat "${hosted_kubecfg}"
-
 echo -e "\nOutput of oc get nodes --kubeconfig='${mgmt_kubecfg}':"
 oc get nodes --kubeconfig="${mgmt_kubecfg}"
 

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -341,7 +341,12 @@ update_file_multi_replace() {
     while [ $i -lt ${#pairs[@]} ]; do
         local placeholder="${pairs[$i]}"
         local value="${pairs[$((i+1))]}"
-        log [INFO] "Replacing ${placeholder} with ${value} in ${target_file}"
+	# check for api keys or secrets e.g. NGC_API_KEY or PULL_SECRET_BASE64, and ensure we don't output their values in log files
+	if [[ "${placeholder^^}" == *API_KEY* || "${placeholder^^}" == *SECRET* ]]; then
+            log [INFO] "Replacing ${placeholder} with [REDACTED] in ${target_file}"
+        else
+            log [INFO] "Replacing ${placeholder} with ${value} in ${target_file}"
+        fi
 
         # Use bash parameter expansion for replacement (handles multi-line naturally)
         content="${content//${placeholder}/${value}}"


### PR DESCRIPTION
Updated scripts in order to redact sensitive info in logs:
- utils.sh
- dpf-sanity-checks.sh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed unnecessary exposure of sensitive configuration data from script output, preventing accidental disclosure of kubeconfig contents.
  * Enhanced log redaction to mask sensitive credentials (API keys and secrets) during script operations, improving data privacy and security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->