### PR TITLE
fix: set LINK_TYPE_P1/P2=ETH in DPUFlavor nvconfig

### DIFF
--- a/manifests/post-installation/dpuflavor-1500.yaml
+++ b/manifests/post-installation/dpuflavor-1500.yaml
@@ -38,6 +38,8 @@ spec:
         - SRIOV_EN=1
         - NUM_OF_VFS=<NUM_VFS>
         - LAG_RESOURCE_ALLOCATION=1
+        - LINK_TYPE_P1=ETH
+        - LINK_TYPE_P2=ETH
   ovs:
     rawConfigScript: |
       #!/bin/bash

--- a/manifests/post-installation/dpuflavor-9000.yaml
+++ b/manifests/post-installation/dpuflavor-9000.yaml
@@ -38,6 +38,8 @@ spec:
         - NUM_OF_VFS=<NUM_VFS>
         - LAG_RESOURCE_ALLOCATION=1
         - NUM_VF_MSIX=48
+        - LINK_TYPE_P1=ETH
+        - LINK_TYPE_P2=ETH
   ovs:
     rawConfigScript: |
       #!/bin/bash


### PR DESCRIPTION
Explicitly set LINK_TYPE_P1=ETH and LINK_TYPE_P2=ETH in both DPUFlavor manifests (1500 and 9000 MTU variants). IB link type is not supported in DPF and leaving this unset can result in the wrong default.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Added support for configurable Ethernet link types on supported device flavors, enabling more flexible network configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->