### PR TITLE
Fix VM deletion nuking all VMs when prefix is empty

### DIFF
--- a/scripts/cluster.sh
+++ b/scripts/cluster.sh
@@ -465,8 +465,12 @@ function clean_all() {
     delete_cluster
     
     # Delete VMs
-    log "INFO" "Deleting VMs with prefix $VM_PREFIX..."
-    scripts/vm.sh delete || true
+    if [ -n "${VM_PREFIX}" ]; then
+        log "INFO" "Deleting VMs with prefix $VM_PREFIX..."
+        scripts/vm.sh delete || true
+    else
+        log "WARN" "VM_PREFIX is empty, skipping VM deletion"
+    fi
     
     # Clean resources
     clean_resources

--- a/scripts/vm.sh
+++ b/scripts/vm.sh
@@ -46,9 +46,13 @@ _resolve_mac() {
 
 _delete_vms_by_prefix() {
     local prefix="$1"
+    if [ -z "${prefix}" ]; then
+        log "WARN" "No VM prefix provided, skipping deletion"
+        return 0
+    fi
     log "INFO" "Deleting VMs matching prefix ${prefix}..."
     local vms
-    vms=$(virsh list --all | grep "${prefix}" | awk '{print $2}')
+    vms=$(virsh list --all | awk '{print $2}' | grep "^${prefix}" || true)
     for vm in ${vms}; do
         virsh destroy "${vm}" 2>/dev/null || true
         virsh undefine "${vm}" --remove-all-storage 2>/dev/null || true
@@ -159,7 +163,9 @@ function create_vms() {
 }
 
 function delete_vms() {
-    _delete_vms_by_prefix "${VM_WORKER_PREFIX}"
+    if [ -n "${VM_WORKER_PREFIX}" ]; then
+        _delete_vms_by_prefix "${VM_WORKER_PREFIX}"
+    fi
     _delete_vms_by_prefix "${VM_PREFIX}"
 }
 
@@ -211,7 +217,9 @@ function create_worker_vms() {
 }
 
 function delete_worker_vms() {
-    _delete_vms_by_prefix "${VM_WORKER_PREFIX}"
+    if [ -n "${VM_WORKER_PREFIX}" ]; then
+        _delete_vms_by_prefix "${VM_WORKER_PREFIX}"
+    fi
 }
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
When VM_PREFIX or VM_WORKER_PREFIX was empty, grep "" matched every line from virsh list --all, destroying all VMs on the hypervisor.

- Guard _delete_vms_by_prefix against empty prefix (skip with warning)
- Use anchored grep on VM name column only (grep "^${prefix}")
- Skip worker VM deletion when VM_WORKER_PREFIX is not set
- Skip VM deletion in clean_all when VM_PREFIX is empty

Made-with: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Safer virtual machine cleanup: deletion is skipped when required configuration is missing to avoid unintended removals.
  * More precise VM matching to reduce false-positive deletions during cleanup.

* **Improvements**
  * Better logging when parameters are absent so skipped cleanup actions are visible to operators.
  * Pipeline robustness: cleanup steps no longer abort on intermediate command failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->