### PR TITLE
Move OLM workaround LVM deployment to post-install stage

### DIFF
--- a/scripts/cluster.sh
+++ b/scripts/cluster.sh
@@ -382,11 +382,6 @@ function start_cluster_installation() {
     log "INFO" "Waiting for cluster to be finalizing..."
     wait_for_cluster_status "finalizing"
 
-    if [[ "${OLM_WORKAROUND}" == "true" ]] && [[ "${STORAGE_TYPE}" != "odf" ]] && [[ "${SKIP_DEPLOY_STORAGE}" != "true" ]]; then
-        log "INFO" "OLM_WORKAROUND=true: deploying LVM via subscription (using catalog ${CATALOG_SOURCE_NAME})"
-        deploy_lvm
-    fi
-
     log "INFO" "Waiting for installation to complete..."
     wait_for_cluster_status "installed"
     log "INFO" "Cluster installation completed successfully"
@@ -400,6 +395,9 @@ function start_cluster_installation() {
         log "INFO" "STORAGE_TYPE=odf detected. Deploying LSO and ODF..."
         deploy_lso
         deploy_odf
+    elif [[ "${OLM_WORKAROUND}" == "true" ]]; then
+        log "INFO" "OLM_WORKAROUND=true: deploying LVM via subscription (using catalog ${CATALOG_SOURCE_NAME})"
+        deploy_lvm
     fi
 }
 


### PR DESCRIPTION
Deploy LVM operator after cluster is fully installed rather than during the finalizing stage, improving API stability and reliability.

Made-with: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized cluster deployment logic for storage configuration handling during the installation process to improve control flow ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->