### PR TITLE
Set ovnDaemonsetVersion based on OCP version

### DIFF
--- a/manifests/post-installation/ovn-configuration.yaml
+++ b/manifests/post-installation/ovn-configuration.yaml
@@ -11,7 +11,7 @@ spec:
         global:
           enableOvnKubeIdentity: false
           imagePullSecretName: "dpf-pull-secret"
-        ovnDaemonsetVersion: "1.1.0"
+        ovnDaemonsetVersion: "<OVN_DAEMONSET_VERSION>"
         k8sAPIServer: https://<HOST_CLUSTER_API>:6443
         podNetwork: 10.128.0.0/14/23
         serviceNetwork: 172.30.0.0/16

--- a/scripts/post-install.sh
+++ b/scripts/post-install.sh
@@ -113,14 +113,21 @@ function update_hbn_ovn_manifests() {
         else
             ovn_mtu=1400
         fi
-        log "INFO" "ovn-configuration will be set with MTU:$ovn_mtu"
+
+        local ovn_daemonset_version="1.1.0"
+        if ocp_version_gte "${OPENSHIFT_VERSION}" "4.22"; then
+            ovn_daemonset_version="1.2.0"
+        fi
+
+        log "INFO" "ovn-configuration will be set with MTU:$ovn_mtu ovnDaemonsetVersion:$ovn_daemonset_version"
         update_file_multi_replace \
             "${POST_INSTALL_DIR}/ovn-configuration.yaml" \
             "${GENERATED_POST_INSTALL_DIR}/ovn-configuration.yaml" \
             "<HBN_OVN_NETWORK>" "${HBN_OVN_NETWORK}" \
             "<HOST_CLUSTER_API>" "${HOST_CLUSTER_API}" \
             "<DPU_HOST_CIDR>" "${DPU_HOST_CIDR}" \
-            "<NODES_MTU>" "${ovn_mtu}"
+            "<NODES_MTU>" "${ovn_mtu}" \
+            "<OVN_DAEMONSET_VERSION>" "${ovn_daemonset_version}"
     fi
     
     # Update hbn-configuration.yaml 


### PR DESCRIPTION
Use 1.2.0 for OCP >= 4.22, keep 1.1.0 for older versions.

Made-with: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OVN daemonset version is now automatically configured based on OpenShift version, using version 1.2.0 for OpenShift 4.22+ and 1.1.0 for earlier versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->