### PR TITLE
Update defaults to OCP 4.22.0-ec.5 and enable OLM workaround

### DIFF
--- a/ci/env.defaults
+++ b/ci/env.defaults
@@ -6,8 +6,8 @@
 # Syntax: ${VAR:-default} means "use default if VAR is unset or empty"
 
 # Cluster Configuration
-OPENSHIFT_VERSION=${OPENSHIFT_VERSION:-4.21.1}
-OLM_WORKAROUND=${OLM_WORKAROUND:-false}
+OPENSHIFT_VERSION=${OPENSHIFT_VERSION:-4.22.0-ec.5}
+OLM_WORKAROUND=${OLM_WORKAROUND:-true}
 
 # Bridge Configuration
 BRIDGE_NAME=${BRIDGE_NAME:-mgmt-br}


### PR DESCRIPTION
Made-with: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default OpenShift version to 4.22.0-ec.5.
  * Enabled OLM workaround in default configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->