### PR TITLE
Move static net files to generated dir instead of configuration_templates

### DIFF
--- a/ci/env.defaults
+++ b/ci/env.defaults
@@ -103,8 +103,8 @@ SLEEP_TIME=${SLEEP_TIME:-60}
 DISK_PATH=${DISK_PATH:-/var/lib/libvirt/images}
 ISO_FOLDER=${ISO_FOLDER:-/var/lib/libvirt/images}
 ISO_TYPE=${ISO_TYPE:-minimal}
-STATIC_NET_FILE=${STATIC_NET_FILE:-./configuration_templates/static_net.yaml}
-WORKER_STATIC_NET_FILE=${WORKER_STATIC_NET_FILE:-./configuration_templates/worker_static_net.yaml}
+STATIC_NET_FILE=${STATIC_NET_FILE:-${GENERATED_DIR}/static_net.yaml}
+WORKER_STATIC_NET_FILE=${WORKER_STATIC_NET_FILE:-${GENERATED_DIR}/worker_static_net.yaml}
 
 # Storage
 STORAGE_TYPE=${STORAGE_TYPE:-lvm}

--- a/scripts/cluster.sh
+++ b/scripts/cluster.sh
@@ -202,9 +202,8 @@ EOF
 
 function set_node_nmstate() {
 
-    if [ -f "$STATIC_NET_FILE" ]; then
-        rm "$STATIC_NET_FILE"
-    fi
+    mkdir -p "$(dirname "$STATIC_NET_FILE")"
+    rm -f "$STATIC_NET_FILE"
 
     if [[ "${VM_STATIC_IP}" != "true" ]] && [[ "${NODES_MTU}" == "1500" || -z "${NODES_MTU}" ]]; then
         log "INFO" "MTU is 1500 and no static IP configured, skipping NMState configuration"
@@ -850,6 +849,7 @@ function main() {
             # Apply worker NMState (MTU) to InfraEnv before downloading the ISO
             if [ "${VM_WORKER_COUNT:-0}" -gt 0 ] && [ "${NODES_MTU}" != "1500" ]; then
                 log "INFO" "Generating worker NMState config (MTU=${NODES_MTU})..."
+                mkdir -p "$(dirname "$WORKER_STATIC_NET_FILE")"
                 rm -f "$WORKER_STATIC_NET_FILE"
                 echo "static_network_config:" >> "$WORKER_STATIC_NET_FILE"
                 _generate_nmstate_dhcp_entries "$WORKER_STATIC_NET_FILE" "$VM_WORKER_COUNT" "$VM_WORKER_PREFIX" "$VM_COUNT"


### PR DESCRIPTION
Move static net files to generated dir instead of configuration_templates

The STATIC_NET_FILE and WORKER_STATIC_NET_FILE were defaulting to ./configuration_templates/ which is not part of the project structure, not cleaned up by clean_resources(), and not in .gitignore. Move them to $GENERATED_DIR where all other generated artifacts live.

Made-with: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default file path configuration for static network and worker state files to use generated directories instead of template locations for improved consistency.
  * Enhanced cluster setup and deployment scripts with improved directory management, ensuring parent directories are automatically created before file operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->