### PR TITLE
Add deploy-lvms to make all and make the target functional

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -211,7 +211,7 @@ deploy-odf:
 	@$(CLUSTER_SCRIPT) deploy-odf
 
 deploy-lvms:
-	@echo "INFO: LVMS is configured automatically when STORAGE_TYPE=lvm (default)"
+	@$(CLUSTER_SCRIPT) deploy-lvm
 
 install-hypershift:
 	@$(TOOLS_SCRIPT) install-hypershift

--- a/scripts/cluster.sh
+++ b/scripts/cluster.sh
@@ -496,6 +496,16 @@ function validate_storage_classes_available() {
 }
 
 function deploy_lvm() {
+    if [ "${SKIP_DEPLOY_STORAGE}" = "true" ]; then
+        log "INFO" "SKIP_DEPLOY_STORAGE=true: skipping LVM deployment"
+        return 0
+    fi
+
+    if [ "${STORAGE_TYPE}" != "lvm" ]; then
+        log "INFO" "STORAGE_TYPE=${STORAGE_TYPE}: skipping LVM deployment"
+        return 0
+    fi
+
     log "INFO" "Deploying LVM Storage operator with catalog source ${CATALOG_SOURCE_NAME}..."
     get_kubeconfig
 


### PR DESCRIPTION
The deploy-lvms Makefile target was a no-op that only printed an info message. Wire it to actually call deploy_lvm, add guards for SKIP_DEPLOY_STORAGE and STORAGE_TYPE!=lvm, and include it in the _all target so LVM is deployed even when re-running against an already installed cluster.

Made-with: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed LVMS deployment execution via the `deploy-lvms` make target to properly deploy the LVM Storage operator instead of only displaying informational messages.
  * Added configuration controls to skip LVM Storage deployment when appropriate based on storage type settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->