### PR TITLE
Set rp_filter=2 on br-dpu to allow asymmetric routing

### DIFF
--- a/manifests/cluster-installation/machineconfig-files/apply-nmstate-bridge.sh
+++ b/manifests/cluster-installation/machineconfig-files/apply-nmstate-bridge.sh
@@ -5,8 +5,15 @@ BRIDGE_NAME="br-dpu"
 IP_HINT_FILE="/run/nodeip-configuration/primary-ip"
 TARGET_MTU="$1"
 
+set_bridge_rp_filter_loose() {
+    local bridge="$1"
+    echo "INFO: Setting rp_filter=2 (loose mode) on $bridge"
+    sysctl -w "net.ipv4.conf.${bridge}.rp_filter=2"
+}
+
 validate_bridge_exists() {
     if ip link show "$BRIDGE_NAME" &> /dev/null; then
+        set_bridge_rp_filter_loose "$BRIDGE_NAME"
         echo "INFO: Bridge '$BRIDGE_NAME' already exists. Configuration assumed complete."
         exit 0
     fi
@@ -107,6 +114,8 @@ apply_linux_bridge() {
     if nmstatectl apply /tmp/br-dpu-config.yml; then
         echo "SUCCESS: Bridge $bridge created successfully."
         ip addr show "$bridge"
+
+        set_bridge_rp_filter_loose "$bridge"
     else
         echo "ERROR: Failed to apply NMState configuration." >&2
         rm -f /tmp/br-dpu-config.yml


### PR DESCRIPTION
OVN-K traffic arrives on br-dpu via the DPU but replies may leave through a different path.
Strict reverse-path filtering (rp_filter=1, the default) drops these packets.
Loose mode (rp_filter=2) only requires the source address to be reachable via any interface, which matches the asymmetric routing topology.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Network bridge setup now enables loose-mode reverse path filtering on bridges to improve compatibility and reduce packet filtering restrictions for newly created or detected interfaces.
  * Added informational logs during bridge initialization and creation to increase visibility into the configuration process and aid troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->