### PR TITLE
Update OCP default to 4.22.0-ec.5 and add DPU SA namespace RoleBinding

### DIFF
--- a/ci/env.defaults
+++ b/ci/env.defaults
@@ -6,7 +6,7 @@
 # Syntax: ${VAR:-default} means "use default if VAR is unset or empty"
 
 # Cluster Configuration
-OPENSHIFT_VERSION=${OPENSHIFT_VERSION:-4.22.0-ec.4}
+OPENSHIFT_VERSION=${OPENSHIFT_VERSION:-4.22.0-ec.5}
 OLM_WORKAROUND=${OLM_WORKAROUND:-true}
 
 # Bridge Configuration

--- a/manifests/post-installation/ovn-credentials.yaml
+++ b/manifests/post-installation/ovn-credentials.yaml
@@ -30,3 +30,17 @@ subjects:
 - kind: ServiceAccount
   name: ovn-kubernetes-node-dpu-service
   namespace: openshift-ovn-kubernetes
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: openshift-ovn-kubernetes-node-limited-dpu-service
+  namespace: openshift-ovn-kubernetes
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: openshift-ovn-kubernetes-node-limited
+subjects:
+- kind: ServiceAccount
+  name: ovn-kubernetes-node-dpu-service
+  namespace: openshift-ovn-kubernetes


### PR DESCRIPTION
- Bump default OPENSHIFT_VERSION from ec.4 to ec.5
- Add RoleBinding granting the DPU service account the namespace-scoped openshift-ovn-kubernetes-node-limited Role for configmap and lease access in the openshift-ovn-kubernetes namespace

Made-with: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated OpenShift to version 4.22.0-ec.5
  * Added namespace-scoped access control configuration for OVN Kubernetes networking

<!-- end of auto-generated comment: release notes by coderabbit.ai -->