### PR TITLE
Update Containerfile for ProwCI job to install oc binary and mount repo locally

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,2 +1,22 @@
+FROM quay.io/openshift/origin-cli:4.20 as oc-cli
 FROM registry.access.redhat.com/ubi9/ubi:latest
+
+LABEL org.opencontainers.image.authors="Red Hat Ecosystem Engineering"
+
+USER root
+
+# Copying oc binary
+COPY --from=oc-cli /usr/bin/oc /usr/bin/oc
+
 RUN dnf install -y make git jq findutils openssh-clients rsync && dnf clean all
+
+# Get the source code in there
+WORKDIR /root/dpf-ci
+
+COPY . .
+
+# Make workspace writable for OpenShift's arbitrary user IDs
+# Note: SSH keys should NOT be in the image - they're mounted at runtime from secrets
+RUN chmod 777 /root/dpf-ci -R
+
+ENTRYPOINT ["bash"]


### PR DESCRIPTION

Update Containerfile for ProwCI job to have oc binary and mount repo locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container image build process to include OpenShift CLI tooling via multi-stage build.
  * Added image metadata for improved container registry documentation.
  * Configured container runtime environment with working directory setup, user permissions, and default bash startup command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->