### PR TITLE
OVN daemonset version changed in 4.21.9 not 4.22

### DIFF
--- a/scripts/post-install.sh
+++ b/scripts/post-install.sh
@@ -115,7 +115,7 @@ function update_hbn_ovn_manifests() {
         fi
 
         local ovn_daemonset_version="1.1.0"
-        if ocp_version_gte "${OPENSHIFT_VERSION}" "4.22"; then
+        if ocp_version_gte "${OPENSHIFT_VERSION}" "4.21.9"; then
             ovn_daemonset_version="1.2.0"
         fi
 

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -410,19 +410,7 @@ copy_manifests_with_exclusions() {
 # Returns 0 (true) if $1 >= $2, 1 (false) otherwise.
 # Usage: ocp_version_gte "4.22.1" "4.22" && echo "yes"
 ocp_version_gte() {
-    local ver="$1" threshold="$2"
-    local ver_major ver_minor thr_major thr_minor
-    ver_major="${ver%%.*}"
-    ver_minor="${ver#*.}"; ver_minor="${ver_minor%%.*}"
-    thr_major="${threshold%%.*}"
-    thr_minor="${threshold#*.}"; thr_minor="${thr_minor%%.*}"
-
-    if (( ver_major > thr_major )); then
-        return 0
-    elif (( ver_major == thr_major && ver_minor >= thr_minor )); then
-        return 0
-    fi
-    return 1
+    printf '%s\n%s\n' "$2" "$1" | sort -V -C
 }
 
 function ensure_ssh_key_in_home() {


### PR DESCRIPTION
Trying to install 4.21.9 fails because the wrong version is being used

Also simplified `ocp_version_gte`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated OpenShift version compatibility logic for network configuration. Versions 4.21.9 and above now receive updated daemon set configuration, lowering the previous threshold from version 4.22.
  * Improved version comparison utility for more reliable version detection across different release formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->