### PR TITLE
Default `BLUEFIELD_OCP_IMAGE` to `edge-infrastructure`

### DIFF
--- a/ci/env.defaults
+++ b/ci/env.defaults
@@ -114,7 +114,7 @@ BFB_STORAGE_CLASS=${BFB_STORAGE_CLASS:-lvms-vg1}
 BFB_URL=${BFB_URL:-}
 
 # Bluefield image layer
-BLUEFIELD_OCP_IMAGE=${BLUEFIELD_OCP_IMAGE:-quay.io/eelgaev/rhcos-bfb:4.21.1}
+BLUEFIELD_OCP_IMAGE=${BLUEFIELD_OCP_IMAGE:-quay.io/edge-infrastructure/bluefield-ocp:4.21.8}
 
 # Kubeconfig
 KUBECONFIG=${KUBECONFIG:-./kubeconfig}


### PR DESCRIPTION
The old repo seems to have gone private?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default OCP image configuration for infrastructure initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->