### PR TITLE
Igal/fix nmstate bridge ordering

### DIFF
--- a/manifests/cluster-installation/99-dpu-worker-configuration.yaml
+++ b/manifests/cluster-installation/99-dpu-worker-configuration.yaml
@@ -3,7 +3,7 @@ kind: MachineConfig
 metadata:
   labels:
     machineconfiguration.openshift.io/role: worker
-  name: worker-nmstate-bridge
+  name: dpu-worker-configuration
 spec:
   config:
     ignition:

--- a/manifests/cluster-installation/99-worker-bridge.yaml
+++ b/manifests/cluster-installation/99-worker-bridge.yaml
@@ -31,11 +31,13 @@ spec:
             [Unit]
             Description=Apply NMState bridge configuration
             After=network.target NetworkManager.service nodeip-configuration.service nmstate.service
+            Before=crio.service kubelet.service
             
             [Service]
             Type=oneshot
             ExecStart=/usr/local/bin/apply-nmstate-bridge.sh <NODES_MTU>
             RemainAfterExit=yes
+            TimeoutStartSec=150s
             Restart=on-failure
             RestartSec=10
             

--- a/manifests/cluster-installation/machineconfig-files/apply-nmstate-bridge.sh
+++ b/manifests/cluster-installation/machineconfig-files/apply-nmstate-bridge.sh
@@ -4,6 +4,44 @@ set -e
 BRIDGE_NAME="br-dpu"
 IP_HINT_FILE="/run/nodeip-configuration/primary-ip"
 TARGET_MTU="$1"
+NODE_IP=""
+
+read_node_ip() {
+    if [[ ! -f "$IP_HINT_FILE" ]]; then
+        echo "ERROR: IP hint file not found: $IP_HINT_FILE" >&2
+        return 1
+    fi
+
+    NODE_IP=$(tr -d '[:space:]' < "$IP_HINT_FILE")
+
+    if [[ -z "$NODE_IP" ]]; then
+        echo "ERROR: IP hint file is empty: $IP_HINT_FILE" >&2
+        return 1
+    fi
+
+    echo "INFO: Node IP from hint file: $NODE_IP"
+}
+
+wait_for_bridge_ip() {
+    local bridge="$1"
+    local timeout=120
+    local interval=2
+    local elapsed=0
+
+    echo "INFO: Waiting up to ${timeout}s for $bridge to acquire $NODE_IP..."
+    while (( elapsed < timeout )); do
+        if ip -o addr show dev "$bridge" | grep -qw "$NODE_IP"; then
+            echo "INFO: $bridge has $NODE_IP."
+            ip addr show dev "$bridge"
+            return 0
+        fi
+        sleep "$interval"
+        elapsed=$(( elapsed + interval ))
+    done
+
+    echo "ERROR: $bridge did not acquire $NODE_IP within ${timeout}s." >&2
+    return 1
+}
 
 set_bridge_rp_filter_loose() {
     local bridge="$1"
@@ -13,36 +51,20 @@ set_bridge_rp_filter_loose() {
 
 validate_bridge_exists() {
     if ip link show "$BRIDGE_NAME" &> /dev/null; then
+        echo "INFO: Bridge '$BRIDGE_NAME' already exists, waiting for IP..."
+        wait_for_bridge_ip "$BRIDGE_NAME"
         set_bridge_rp_filter_loose "$BRIDGE_NAME"
-        echo "INFO: Bridge '$BRIDGE_NAME' already exists. Configuration assumed complete."
         exit 0
     fi
 }
 
 get_nodeip_hint_interface() {
-    local ip_hint_file="$1"
-
-    if [[ ! -f "${ip_hint_file}" ]]; then
-        echo "ERROR: IP hint file not found: $ip_hint_file" >&2
-        return 1
-    fi
-
-    local ip_hint
-    ip_hint=$(tr -d '[:space:]' < "${ip_hint_file}")
-
-    if [[ -z "${ip_hint}" ]]; then
-        echo "ERROR: IP hint file is empty: $ip_hint_file" >&2
-        return 1
-    fi
-
-    echo "INFO: Node IP from hint file: $ip_hint" >&2
-
     local iface
-    iface=$(ip -j addr | jq -r --arg ip "$ip_hint" --arg br "$BRIDGE_NAME" \
+    iface=$(ip -j addr | jq -r --arg ip "$NODE_IP" --arg br "$BRIDGE_NAME" \
         'first(.[] | select(any(.addr_info[]; .local==$ip) and .ifname!=$br)) | .ifname')
 
     if [[ -z "${iface}" || "${iface}" == "null" ]]; then
-        echo "ERROR: No interface found with IP $ip_hint" >&2
+        echo "ERROR: No interface found with IP $NODE_IP" >&2
         return 1
     fi
 
@@ -113,6 +135,7 @@ apply_linux_bridge() {
     echo "INFO: Applying configuration via nmstatectl..."
     if nmstatectl apply /tmp/br-dpu-config.yml; then
         echo "SUCCESS: Bridge $bridge created successfully."
+        wait_for_bridge_ip "$bridge"
         ip addr show "$bridge"
 
         set_bridge_rp_filter_loose "$bridge"
@@ -126,6 +149,7 @@ apply_linux_bridge() {
 }
 
 # --- Main ---
+read_node_ip
 validate_bridge_exists
-SELECTED_IFACE=$(get_nodeip_hint_interface "${IP_HINT_FILE}")
+SELECTED_IFACE=$(get_nodeip_hint_interface)
 apply_linux_bridge "$SELECTED_IFACE" "$TARGET_MTU"

--- a/scripts/manifests.sh
+++ b/scripts/manifests.sh
@@ -51,7 +51,7 @@ function prepare_cluster_manifests() {
         "ovn-values-with-injector.yaml"
         "nfd-subscription.yaml"
         "openshift-cert-manager.yaml"
-        "99-worker-bridge.yaml"
+        "99-dpu-worker-configuration.yaml"
     )
 
     excluded_files+=("olm-catalogsource-template.yaml")
@@ -134,8 +134,8 @@ update_worker_manifest() {
     b64_unmanage=$(base64 -w 0 < "$mc_files_dir/unmanage-ovnk-interface.conf")
 
     update_file_multi_replace \
-            "$MANIFESTS_DIR/cluster-installation/99-worker-bridge.yaml" \
-            "$GENERATED_DIR/99-worker-bridge.yaml" \
+            "$MANIFESTS_DIR/cluster-installation/99-dpu-worker-configuration.yaml" \
+            "$GENERATED_DIR/99-dpu-worker-configuration.yaml" \
             "<NODES_MTU>" "$mtu" \
             "<BASE64_APPLY_NMSTATE_BRIDGE>" "$b64_bridge" \
             "<BASE64_CONFIGURE_P0_ROUTING>" "$b64_routing" \


### PR DESCRIPTION
fix: order nmstate-bridge.service before crio and kubelet
During boot, nmstate-bridge.service creates the br-dpu bridge and moves
eno12399 under it. This briefly removes the node IP from the system while
br-dpu acquires a new DHCP lease. If crio starts during this window, it
fails to bind its streaming server to the node IP (EADDRNOTAVAIL), which
cascades into a kubelet dependency failure that doesn't auto-recover.

Adding Before=crio.service kubelet.service ensures the bridge is fully
configured and the IP is available before either service starts.

rename worker-nmstate-bridge to dpu-worker-configuration
Rename the MachineConfig and its manifest file to better reflect
its purpose as the DPU worker node configuration.

Made-with: Cursor



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Renamed the DPU worker configuration artifact and updated manifest handling to use the new configuration name.

* **Bug Fixes**
  * Ensures DPU init runs before the container runtime and kubelet, and adds an explicit startup timeout.
  * Improves bridge IP detection and interface selection by waiting for the bridge to acquire the node IP for more reliable network setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->