### PR TITLE
[wip] Add DPF log collection from host and DPUCluster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,13 +36,13 @@ WORKER_SCRIPT := scripts/worker.sh
         delete-dpf-hcp-provisioner-operator \
         verify-deployment verify-workers verify-dpu-nodes verify-dpudeployment \
         run-traffic-flow-tests tft-setup tft-cleanup tft-show-config tft-results aicli-list \
-        validate-env-files generate-env
+        validate-env-files generate-env deploy-observability
 
 all: 
 	@mkdir -p logs
 	@bash -o pipefail -c '$(MAKE) _all 2>&1 | tee "logs/make_all_$(shell date +%Y%m%d_%H%M%S).log"'
 
-_all: verify-files check-cluster create-vms prepare-manifests cluster-install update-etc-hosts kubeconfig add-worker-nodes deploy-dpf prepare-dpu-files deploy-dpu-services enable-ovn-injector
+_all: verify-files check-cluster create-vms prepare-manifests cluster-install update-etc-hosts kubeconfig add-worker-nodes deploy-dpf prepare-dpu-files deploy-dpu-services enable-ovn-injector deploy-observability
 	@echo ""
 	@echo "================================================================================"
 	@echo "✅ DPF Installation Complete!"
@@ -166,6 +166,9 @@ prepare-dpu-files:
 
 deploy-dpu-services: prepare-dpu-files
 	@$(POST_INSTALL_SCRIPT) apply
+
+deploy-observability:
+	@$(POST_INSTALL_SCRIPT) observability
 
 deploy-hypershift: install-helm
 	@$(DPF_SCRIPT) deploy-hypershift

--- a/manifests/observability/dpf-metrics/dpf-controller-podmonitor.yaml
+++ b/manifests/observability/dpf-metrics/dpf-controller-podmonitor.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: dpf-controller-manager
+  namespace: dpf-operator-system
+  labels:
+    app.kubernetes.io/part-of: dpf
+spec:
+  namespaceSelector:
+    matchNames:
+      - dpf-operator-system
+  selector:
+    matchExpressions:
+      - key: dpu.nvidia.com/component
+        operator: Exists
+  podMetricsEndpoints:
+    - port: metrics
+      path: /metrics
+      interval: 30s
+      scheme: https
+      authorization:
+        type: Bearer
+        credentials:
+          name: dpf-controller-metrics-reader-token
+          key: token
+      tlsConfig:
+        insecureSkipVerify: true
+      relabelings:
+        - sourceLabels: [__meta_kubernetes_pod_label_dpu_nvidia_com_component]
+          regex: ".*-controller-manager"
+          action: keep

--- a/manifests/observability/dpf-metrics/dpf-controller-rbac.yaml
+++ b/manifests/observability/dpf-metrics/dpf-controller-rbac.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: dpf-controller-metrics-reader
+  namespace: dpf-operator-system
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: dpf-controller-metrics-reader-token
+  namespace: dpf-operator-system
+  annotations:
+    kubernetes.io/service-account.name: dpf-controller-metrics-reader
+type: kubernetes.io/service-account-token
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: dpf-controller-metrics-reader
+rules:
+  - nonResourceURLs: ["/metrics"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: dpf-controller-metrics-reader
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: dpf-controller-metrics-reader
+subjects:
+  - kind: ServiceAccount
+    name: dpf-controller-metrics-reader
+    namespace: dpf-operator-system

--- a/manifests/observability/dpf-metrics/kube-state-metrics-deployment.yaml
+++ b/manifests/observability/dpf-metrics/kube-state-metrics-deployment.yaml
@@ -1,0 +1,98 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dpf-host-kube-state-metrics
+  namespace: dpf-operator-system
+  labels:
+    app.kubernetes.io/name: kube-state-metrics
+    app.kubernetes.io/instance: dpf-host-kube-state-metrics
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kube-state-metrics
+      app.kubernetes.io/instance: dpf-host-kube-state-metrics
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: kube-state-metrics
+        app.kubernetes.io/instance: dpf-host-kube-state-metrics
+    spec:
+      serviceAccountName: dpf-host-kube-state-metrics
+      containers:
+        - name: kube-state-metrics
+          image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.18.0
+          imagePullPolicy: IfNotPresent
+          args:
+            - --custom-resource-state-config-file=/etc/customresourcestate/config.yaml
+            - --custom-resource-state-only=true
+            - --port=8080
+            - --telemetry-port=8081
+          ports:
+            - name: http-metrics
+              containerPort: 8080
+              protocol: TCP
+            - name: telemetry
+              containerPort: 8081
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8081
+            initialDelaySeconds: 5
+            timeoutSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+            initialDelaySeconds: 5
+            timeoutSeconds: 5
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - name: customresourcestate-config
+              mountPath: /etc/customresourcestate
+              readOnly: true
+      volumes:
+        - name: customresourcestate-config
+          configMap:
+            name: dpf-operator-customresourcestate-config
+            defaultMode: 420
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: dpf-host-kube-state-metrics
+  namespace: dpf-operator-system
+  labels:
+    app.kubernetes.io/name: kube-state-metrics
+    app.kubernetes.io/instance: dpf-host-kube-state-metrics
+spec:
+  type: ClusterIP
+  clusterIP: None
+  selector:
+    app.kubernetes.io/name: kube-state-metrics
+    app.kubernetes.io/instance: dpf-host-kube-state-metrics
+  ports:
+    - name: http-metrics
+      port: 8080
+      targetPort: http-metrics
+      protocol: TCP
+    - name: telemetry
+      port: 8081
+      targetPort: telemetry
+      protocol: TCP

--- a/manifests/observability/dpf-metrics/kube-state-metrics-rbac.yaml
+++ b/manifests/observability/dpf-metrics/kube-state-metrics-rbac.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: dpf-host-kube-state-metrics
+  namespace: dpf-operator-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: dpf-host-kube-state-metrics
+rules:
+  - apiGroups:
+      - svc.dpu.nvidia.com
+      - operator.dpu.nvidia.com
+      - provisioning.dpu.nvidia.com
+      - storage.dpu.nvidia.com
+      - vpc.dpu.nvidia.com
+    resources: ["*"]
+    verbs: ["list", "watch"]
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: dpf-host-kube-state-metrics
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: dpf-host-kube-state-metrics
+subjects:
+  - kind: ServiceAccount
+    name: dpf-host-kube-state-metrics
+    namespace: dpf-operator-system

--- a/manifests/observability/dpf-metrics/kube-state-metrics-servicemonitor.yaml
+++ b/manifests/observability/dpf-metrics/kube-state-metrics-servicemonitor.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: dpf-host-kube-state-metrics
+  namespace: dpf-operator-system
+  labels:
+    app.kubernetes.io/name: kube-state-metrics
+    app.kubernetes.io/instance: dpf-host-kube-state-metrics
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kube-state-metrics
+      app.kubernetes.io/instance: dpf-host-kube-state-metrics
+  endpoints:
+    - port: http-metrics
+      interval: 30s
+      path: /metrics
+      honorLabels: true

--- a/manifests/observability/grafana/grafana-cr.yaml
+++ b/manifests/observability/grafana/grafana-cr.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: Grafana
+metadata:
+  name: dpf-grafana
+  namespace: dpf-operator-system
+  labels:
+    dashboards: "dpf-grafana"
+spec:
+  route:
+    spec:
+      port:
+        targetPort: grafana
+      tls:
+        termination: edge
+  config:
+    log:
+      mode: "console"
+      level: "info"
+    auth.anonymous:
+      enabled: "true"
+      org_role: "Viewer"
+    security:
+      admin_user: "admin"
+      admin_password: "admin"

--- a/manifests/observability/grafana/grafana-dashboards.yaml
+++ b/manifests/observability/grafana/grafana-dashboards.yaml
@@ -1,0 +1,65 @@
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: doca-platform-framework-state
+  namespace: dpf-operator-system
+spec:
+  instanceSelector:
+    matchLabels:
+      dashboards: "dpf-grafana"
+  configMapRef:
+    name: dpf-operator-grafana-dashboards
+    key: doca-platform-framework-state.json
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: doca-platform-dpu-detail
+  namespace: dpf-operator-system
+spec:
+  instanceSelector:
+    matchLabels:
+      dashboards: "dpf-grafana"
+  configMapRef:
+    name: dpf-operator-grafana-dashboards
+    key: doca-platform-dpu-detail.json
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: doca-platform-dpu-fleet-health
+  namespace: dpf-operator-system
+spec:
+  instanceSelector:
+    matchLabels:
+      dashboards: "dpf-grafana"
+  configMapRef:
+    name: dpf-operator-grafana-dashboards
+    key: doca-platform-dpu-fleet-health.json
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: controller-runtime
+  namespace: dpf-operator-system
+spec:
+  instanceSelector:
+    matchLabels:
+      dashboards: "dpf-grafana"
+  configMapRef:
+    name: dpf-operator-grafana-debug-dashboards
+    key: controller-runtime.json
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: doca-platform-framework-performance
+  namespace: dpf-operator-system
+spec:
+  instanceSelector:
+    matchLabels:
+      dashboards: "dpf-grafana"
+  configMapRef:
+    name: dpf-operator-grafana-debug-dashboards
+    key: doca-platform-framework-performance.json

--- a/manifests/observability/grafana/grafana-datasource.yaml
+++ b/manifests/observability/grafana/grafana-datasource.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDatasource
+metadata:
+  name: prometheus
+  namespace: dpf-operator-system
+spec:
+  instanceSelector:
+    matchLabels:
+      dashboards: "dpf-grafana"
+  valuesFrom:
+    - targetPath: "secureJsonData.httpHeaderValue1"
+      valueFrom:
+        secretKeyRef:
+          name: grafana-prometheus-reader-token
+          key: token
+  datasource:
+    name: prometheus
+    type: prometheus
+    uid: prometheus
+    access: proxy
+    url: https://thanos-querier.openshift-monitoring.svc.cluster.local:9091
+    isDefault: true
+    jsonData:
+      tlsSkipVerify: true
+      httpHeaderName1: "Authorization"
+      timeInterval: "30s"
+    secureJsonData:
+      httpHeaderValue1: "Bearer ${token}"

--- a/manifests/observability/grafana/grafana-rbac.yaml
+++ b/manifests/observability/grafana/grafana-rbac.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: grafana-prometheus-reader
+  namespace: dpf-operator-system
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: grafana-prometheus-reader-token
+  namespace: dpf-operator-system
+  annotations:
+    kubernetes.io/service-account.name: grafana-prometheus-reader
+type: kubernetes.io/service-account-token
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: grafana-prometheus-reader-cluster-monitoring
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-monitoring-view
+subjects:
+  - kind: ServiceAccount
+    name: grafana-prometheus-reader
+    namespace: dpf-operator-system

--- a/manifests/observability/logging/cluster-logging-subscription.yaml
+++ b/manifests/observability/logging/cluster-logging-subscription.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-logging
+  labels:
+    openshift.io/cluster-monitoring: "true"
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: cluster-logging
+  namespace: openshift-logging
+spec:
+  targetNamespaces:
+    - openshift-logging
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: cluster-logging
+  namespace: openshift-logging
+spec:
+  channel: stable-6.5
+  name: cluster-logging
+  source: redhat-operators-v4.21
+  sourceNamespace: openshift-marketplace
+  installPlanApproval: Automatic

--- a/manifests/observability/logging/clusterlogforwarder.yaml
+++ b/manifests/observability/logging/clusterlogforwarder.yaml
@@ -1,0 +1,53 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: logcollector
+  namespace: openshift-logging
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: logcollector-application-logs
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: collect-application-logs
+subjects:
+  - kind: ServiceAccount
+    name: logcollector
+    namespace: openshift-logging
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: logcollector-infrastructure-logs
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: collect-infrastructure-logs
+subjects:
+  - kind: ServiceAccount
+    name: logcollector
+    namespace: openshift-logging
+---
+apiVersion: observability.openshift.io/v1
+kind: ClusterLogForwarder
+metadata:
+  name: instance
+  namespace: openshift-logging
+spec:
+  serviceAccount:
+    name: logcollector
+  outputs:
+    - name: loki
+      type: loki
+      loki:
+        url: http://loki.dpf-operator-system.svc.cluster.local:3100
+  pipelines:
+    - name: app-and-infra
+      inputRefs:
+        - application
+        - infrastructure
+      outputRefs:
+        - loki

--- a/manifests/observability/logging/grafana-loki-datasource.yaml
+++ b/manifests/observability/logging/grafana-loki-datasource.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDatasource
+metadata:
+  name: loki
+  namespace: dpf-operator-system
+spec:
+  instanceSelector:
+    matchLabels:
+      dashboards: "dpf-grafana"
+  datasource:
+    name: loki
+    type: loki
+    uid: loki
+    access: proxy
+    url: http://loki.dpf-operator-system.svc.cluster.local:3100
+    isDefault: false
+    jsonData:
+      maxLines: 1000

--- a/manifests/observability/logging/loki.yaml
+++ b/manifests/observability/logging/loki.yaml
@@ -1,0 +1,180 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: loki
+  namespace: dpf-operator-system
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: loki-config
+  namespace: dpf-operator-system
+data:
+  loki.yaml: |
+    auth_enabled: false
+    server:
+      http_listen_port: 3100
+      grpc_listen_port: 9095
+      log_level: info
+    common:
+      path_prefix: /var/loki
+      replication_factor: 1
+      storage:
+        filesystem:
+          chunks_directory: /var/loki/chunks
+          rules_directory: /var/loki/rules
+      ring:
+        kvstore:
+          store: inmemory
+        instance_addr: 127.0.0.1
+    schema_config:
+      configs:
+        - from: "2024-01-01"
+          store: tsdb
+          object_store: filesystem
+          schema: v13
+          index:
+            prefix: loki_index_
+            period: 24h
+    limits_config:
+      retention_period: 24h
+      max_query_series: 10000
+      ingestion_rate_mb: 50
+      ingestion_burst_size_mb: 100
+      allow_structured_metadata: true
+      otlp_config:
+        resource_attributes:
+          attributes_config:
+            - action: index_label
+              attributes:
+                - k8s.namespace.name
+                - k8s.pod.name
+                - k8s.container.name
+                - cluster
+    compactor:
+      working_directory: /var/loki/compactor
+      retention_enabled: true
+      delete_request_store: filesystem
+    ruler:
+      storage:
+        type: local
+        local:
+          directory: /var/loki/rules
+    analytics:
+      reporting_enabled: false
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: loki
+  namespace: dpf-operator-system
+  labels:
+    app.kubernetes.io/name: loki
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: loki
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: loki
+    spec:
+      serviceAccountName: loki
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 10001
+        fsGroup: 10001
+      containers:
+        - name: loki
+          image: grafana/loki:3.3.2
+          imagePullPolicy: IfNotPresent
+          args:
+            - -config.file=/etc/loki/loki.yaml
+          ports:
+            - name: http-metrics
+              containerPort: 3100
+              protocol: TCP
+            - name: grpc
+              containerPort: 9095
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http-metrics
+            initialDelaySeconds: 10
+            timeoutSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /ready
+              port: http-metrics
+            initialDelaySeconds: 30
+            timeoutSeconds: 5
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 1000m
+              memory: 2Gi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+            readOnlyRootFilesystem: true
+          volumeMounts:
+            - name: config
+              mountPath: /etc/loki
+            - name: storage
+              mountPath: /var/loki
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: config
+          configMap:
+            name: loki-config
+        - name: storage
+          emptyDir:
+            sizeLimit: 10Gi
+        - name: tmp
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: loki
+  namespace: dpf-operator-system
+  labels:
+    app.kubernetes.io/name: loki
+spec:
+  type: ClusterIP
+  ports:
+    - name: http-metrics
+      port: 3100
+      targetPort: http-metrics
+      protocol: TCP
+    - name: grpc
+      port: 9095
+      targetPort: grpc
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: loki
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: loki
+  namespace: dpf-operator-system
+  labels:
+    app.kubernetes.io/name: loki
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: loki
+  endpoints:
+    - port: http-metrics
+      interval: 30s
+      path: /metrics

--- a/manifests/observability/logging/opentelemetry-operator-subscription.yaml
+++ b/manifests/observability/logging/opentelemetry-operator-subscription.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-opentelemetry-operator
+  labels:
+    openshift.io/cluster-monitoring: "true"
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: openshift-opentelemetry-operator
+  namespace: openshift-opentelemetry-operator
+spec: {}
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: opentelemetry-product
+  namespace: openshift-opentelemetry-operator
+spec:
+  channel: stable
+  name: opentelemetry-product
+  source: redhat-operators-v4.21
+  sourceNamespace: openshift-marketplace
+  installPlanApproval: Automatic

--- a/manifests/observability/logging/otel-collector.yaml
+++ b/manifests/observability/logging/otel-collector.yaml
@@ -1,0 +1,55 @@
+---
+apiVersion: opentelemetry.io/v1beta1
+kind: OpenTelemetryCollector
+metadata:
+  name: dpf-otel
+  namespace: dpf-operator-system
+spec:
+  mode: deployment
+  replicas: 1
+  config:
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+            endpoint: 0.0.0.0:4317
+          http:
+            endpoint: 0.0.0.0:4318
+    processors:
+      memory_limiter:
+        check_interval: 5s
+        limit_mib: 1024
+        spike_limit_mib: 256
+      batch:
+        timeout: 10s
+        send_batch_size: 1024
+    exporters:
+      otlphttp/loki:
+        endpoint: http://loki.dpf-operator-system.svc.cluster.local:3100/otlp
+        tls:
+          insecure: true
+    service:
+      pipelines:
+        logs:
+          receivers: [otlp]
+          processors: [memory_limiter, batch]
+          exporters: [otlphttp/loki]
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: dpf-otel-collector-nodeport
+  namespace: dpf-operator-system
+spec:
+  type: NodePort
+  selector:
+    app.kubernetes.io/component: opentelemetry-collector
+    app.kubernetes.io/instance: dpf-operator-system.dpf-otel
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/part-of: opentelemetry
+  ports:
+    - name: otlp-http
+      port: 4318
+      targetPort: 4318
+      nodePort: 30318
+      protocol: TCP

--- a/manifests/observability/operators/grafana-operator-subscription.yaml
+++ b/manifests/observability/operators/grafana-operator-subscription.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: grafana-operator
+  namespace: openshift-operators
+spec:
+  channel: v5
+  name: grafana-operator
+  source: community-operators
+  sourceNamespace: openshift-marketplace
+  installPlanApproval: Automatic

--- a/scripts/post-install.sh
+++ b/scripts/post-install.sh
@@ -405,6 +405,81 @@ function apply_observability() {
     log [INFO] "Applying Grafana manifests..."
     retry 5 30 apply_manifest "${OBSERVABILITY_DIR}/grafana" "true"
 
+    log [INFO] "Applying Loki deployment and Cluster Logging Operator subscription..."
+    retry 5 30 apply_manifest "${OBSERVABILITY_DIR}/logging/cluster-logging-subscription.yaml" "true"
+    retry 5 30 apply_manifest "${OBSERVABILITY_DIR}/logging/loki.yaml" "true"
+
+    log [INFO] "Waiting for Cluster Logging Operator CSV to reach Succeeded..."
+    attempts=0
+    phase=""
+    while [ $attempts -lt 60 ]; do
+        phase=$(oc -n openshift-logging get csv \
+            -l operators.coreos.com/cluster-logging.openshift-logging= \
+            -o jsonpath='{.items[0].status.phase}' 2>/dev/null || true)
+        if [ "$phase" = "Succeeded" ]; then
+            break
+        fi
+        attempts=$((attempts+1))
+        sleep 10
+    done
+    if [ "$phase" != "Succeeded" ]; then
+        log [ERROR] "Cluster Logging Operator CSV did not reach Succeeded after 10 minutes (last phase: '${phase}')"
+        return 1
+    fi
+    log [INFO] "Cluster Logging Operator CSV is Succeeded"
+
+    log [INFO] "Applying ClusterLogForwarder and Loki datasource..."
+    retry 5 30 apply_manifest "${OBSERVABILITY_DIR}/logging/clusterlogforwarder.yaml" "true"
+    retry 5 30 apply_manifest "${OBSERVABILITY_DIR}/logging/grafana-loki-datasource.yaml" "true"
+
+    log [INFO] "Applying OpenTelemetry Operator subscription..."
+    retry 5 30 apply_manifest "${OBSERVABILITY_DIR}/logging/opentelemetry-operator-subscription.yaml" "true"
+
+    log [INFO] "Waiting for OpenTelemetry Operator CSV to reach Succeeded..."
+    attempts=0
+    phase=""
+    while [ $attempts -lt 60 ]; do
+        phase=$(oc -n openshift-opentelemetry-operator get csv \
+            -l operators.coreos.com/opentelemetry-product.openshift-opentelemetry-operator= \
+            -o jsonpath='{.items[0].status.phase}' 2>/dev/null || true)
+        if [ "$phase" = "Succeeded" ]; then
+            break
+        fi
+        attempts=$((attempts+1))
+        sleep 10
+    done
+    if [ "$phase" != "Succeeded" ]; then
+        log [ERROR] "OpenTelemetry Operator CSV did not reach Succeeded after 10 minutes (last phase: '${phase}')"
+        return 1
+    fi
+    log [INFO] "OpenTelemetry Operator CSV is Succeeded"
+
+    log [INFO] "Applying host OpenTelemetryCollector..."
+    retry 5 30 apply_manifest "${OBSERVABILITY_DIR}/logging/otel-collector.yaml" "true"
+
+    log [INFO] "Resolving a host-cluster control-plane node IP for the DPU OTel endpoint..."
+    local host_node_ip=""
+    host_node_ip=$(oc get nodes -l node-role.kubernetes.io/control-plane \
+        -o jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}' 2>/dev/null || true)
+    if [ -z "$host_node_ip" ]; then
+        log [ERROR] "No host-cluster control-plane node found; skipping DPU OTel endpoint patch"
+        return 1
+    fi
+    log [INFO] "Using host control-plane IP ${host_node_ip} for DPU OTel endpoint (NodePort 30318)"
+
+    log [INFO] "Patching DPFOperatorConfig to enable DPU-side OpenTelemetry forwarding..."
+    oc -n dpf-operator-system patch dpfoperatorconfig dpfoperatorconfig --type=merge -p "{
+      \"spec\": {
+        \"monitoring\": {
+          \"openTelemetryCollector\": {
+            \"logging\": {
+              \"endpoint\": \"http://${host_node_ip}:30318\"
+            }
+          }
+        }
+      }
+    }" || log [WARN] "DPFOperatorConfig patch failed; DPU-side OTel will not be enabled"
+
     log [INFO] "Observability manifest application completed successfully"
 }
 

--- a/scripts/post-install.sh
+++ b/scripts/post-install.sh
@@ -15,6 +15,7 @@ MANIFESTS_DIR=${MANIFESTS_DIR:-"manifests"}
 POST_INSTALL_DIR="${MANIFESTS_DIR}/post-installation"
 GENERATED_DIR=${GENERATED_DIR:-"$MANIFESTS_DIR/generated"}
 GENERATED_POST_INSTALL_DIR="${GENERATED_DIR}/post-install"
+OBSERVABILITY_DIR="${MANIFESTS_DIR}/observability"
 
 # BFB Configuration with defaults
 BFB_URL=${BFB_URL:-"http://10.8.2.236/bfb/rhcos_4.19.0-ec.4_installer_2025-04-23_07-48-42.bfb"}
@@ -359,6 +360,54 @@ function apply_post_installation() {
     log [INFO] "Post-installation manifest application completed successfully"
 }
 
+function apply_observability() {
+    log [INFO] "Starting observability manifest application..."
+
+    if [ ! -d "${OBSERVABILITY_DIR}" ]; then
+        log [ERROR] "Observability directory not found: ${OBSERVABILITY_DIR}"
+        exit 1
+    fi
+
+    get_kubeconfig
+
+    log [INFO] "Applying observability operator subscriptions..."
+    retry 5 30 apply_manifest "${OBSERVABILITY_DIR}/operators" "true"
+
+    log [INFO] "Waiting for Grafana Operator CSV to reach Succeeded..."
+    local attempts=0
+    local phase=""
+    while [ $attempts -lt 60 ]; do
+        phase=$(oc -n openshift-operators get csv \
+            -l operators.coreos.com/grafana-operator.openshift-operators= \
+            -o jsonpath='{.items[0].status.phase}' 2>/dev/null || true)
+        if [ "$phase" = "Succeeded" ]; then
+            break
+        fi
+        attempts=$((attempts+1))
+        sleep 10
+    done
+    if [ "$phase" != "Succeeded" ]; then
+        log [ERROR] "Grafana Operator CSV did not reach Succeeded after 10 minutes (last phase: '${phase}')"
+        return 1
+    fi
+    log [INFO] "Grafana Operator CSV is Succeeded"
+
+    log [INFO] "Applying DPF metrics manifests..."
+    retry 5 30 apply_manifest "${OBSERVABILITY_DIR}/dpf-metrics" "true"
+
+    # Works around a UWM prometheus-operator namespace-cache race where newly
+    # applied PodMonitors in dpf-operator-system aren't rendered into the
+    # Prometheus scrape config until the operator is kicked. See WA-005.
+    log [INFO] "Restarting UWM prometheus-operator to refresh PodMonitor cache..."
+    oc -n openshift-user-workload-monitoring rollout restart deploy/prometheus-operator || true
+    oc -n openshift-user-workload-monitoring rollout status deploy/prometheus-operator --timeout=120s || true
+
+    log [INFO] "Applying Grafana manifests..."
+    retry 5 30 apply_manifest "${OBSERVABILITY_DIR}/grafana" "true"
+
+    log [INFO] "Observability manifest application completed successfully"
+}
+
 function redeploy() {
     log [INFO] "Redeploying DPU..."
     prepare_post_installation
@@ -382,10 +431,10 @@ function redeploy() {
 # If script is executed directly (not sourced), run the appropriate function
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
     if [ $# -lt 1 ]; then
-        log [ERROR] "Usage: $0 <prepare|apply|redeploy>"
+        log [ERROR] "Usage: $0 <prepare|apply|redeploy|observability>"
         exit 1
     fi
-    
+
     case "$1" in
         prepare)
             prepare_post_installation
@@ -396,9 +445,12 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
         redeploy)
             redeploy
             ;;
+        observability)
+            apply_observability
+            ;;
         *)
             log [ERROR] "Unknown command: $1"
-            log [ERROR] "Available commands: prepare, apply, redeploy"
+            log [ERROR] "Available commands: prepare, apply, redeploy, observability"
             exit 1
             ;;
     esac


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Deployed comprehensive observability stack with Grafana for metrics visualization
  * Integrated centralized log aggregation and forwarding via Loki
  * Enabled metrics collection for DPF controllers and Kubernetes cluster state
  * Added distributed tracing support with OpenTelemetry and collector
  * Included pre-built Grafana dashboards for monitoring DPU state, performance, and fleet health

<!-- end of auto-generated comment: release notes by coderabbit.ai -->