### PR TITLE
Set bluefield-ocp to 4.21.0 with a beta DOCA 3.4.0 build

### DIFF
--- a/ci/env.defaults
+++ b/ci/env.defaults
@@ -114,7 +114,7 @@ BFB_STORAGE_CLASS=${BFB_STORAGE_CLASS:-lvms-vg1}
 BFB_URL=${BFB_URL:-}
 
 # Bluefield image layer
-BLUEFIELD_OCP_IMAGE=${BLUEFIELD_OCP_IMAGE:-quay.io/edge-infrastructure/bluefield-ocp:4.21.8}
+BLUEFIELD_OCP_IMAGE=${BLUEFIELD_OCP_IMAGE:-quay.io/eelgaev/bluefield-ocp:4.21.0_3.4.0-beta}
 
 # Kubeconfig
 KUBECONFIG=${KUBECONFIG:-./kubeconfig}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default container image version used in deployment processes from 4.21.8 to 4.21.0_3.4.0-beta.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->