### PR TITLE
Support DISK_PATH and Enable UEFI by default

### DIFF
--- a/scripts/vm.sh
+++ b/scripts/vm.sh
@@ -68,13 +68,14 @@ _create_vm() {
     nohup virt-install --name "$vm_name" --memory "$ram" \
             --vcpus "$vcpus" \
             --os-variant=rhel9.4 \
-            --disk pool=default,size="${disk1}" \
-            --disk pool=default,size="${disk2}" \
+            --disk path="${DISK_PATH}/${vm_name}-disk1.qcow2",size="${disk1}" \
+            --disk path="${DISK_PATH}/${vm_name}-disk2.qcow2",size="${disk2}" \
             --network "${network_arg}" \
             --graphics=vnc \
             --events on_reboot=restart \
             --cdrom "$ISO_PATH" \
             --cpu host-passthrough \
+            --boot uefi \
             --noautoconsole \
             --wait=-1 &
 }


### PR DESCRIPTION
This PR makes sure `DISK_PATH` will be in use by `virt-install` in `scripts/vm.sh`, and the VMs will be created with UEFI firmware by default.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default container image reference.

* **New Features**
  * VM creation now supports UEFI boot and explicit disk provisioning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->