### PR TITLE
fix: handle UEFI VMs in virsh undefine by adding --nvram fallback

### DIFF
--- a/scripts/vm.sh
+++ b/scripts/vm.sh
@@ -55,7 +55,8 @@ _delete_vms_by_prefix() {
     vms=$(virsh list --all | awk '{print $2}' | grep "^${prefix}" || true)
     for vm in ${vms}; do
         virsh destroy "${vm}" 2>/dev/null || true
-        virsh undefine "${vm}" --remove-all-storage 2>/dev/null || true
+        virsh undefine "${vm}" --remove-all-storage --nvram 2>/dev/null \
+            || virsh undefine "${vm}" --remove-all-storage 2>/dev/null || true
     done
     log "INFO" "VMs matching prefix ${prefix} deleted"
 }


### PR DESCRIPTION
VMs created with UEFI firmware have NVRAM, causing `virsh undefine --remove-all-storage` to fail with "cannot undefine domain with nvram". Try --nvram first for UEFI VMs, fall back to without it for legacy BIOS VMs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced VM deletion robustness with improved error handling and fallback mechanisms for more reliable resource cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->