### PR TITLE
fix: undefine vram in vm deleted

### DIFF
--- a/scripts/vm.sh
+++ b/scripts/vm.sh
@@ -55,7 +55,7 @@ _delete_vms_by_prefix() {
     vms=$(virsh list --all | awk '{print $2}' | grep "^${prefix}" || true)
     for vm in ${vms}; do
         virsh destroy "${vm}" 2>/dev/null || true
-        virsh undefine "${vm}" --remove-all-storage 2>/dev/null || true
+        virsh undefine "${vm}" --nvram --remove-all-storage 2>/dev/null || true
     done
     log "INFO" "VMs matching prefix ${prefix} deleted"
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved virtual machine cleanup behavior to more completely remove system state during deletion operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->