### PR TITLE
Add delete-worker functionality for BMH and Machine-based workers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -348,6 +348,27 @@ add-worker-nodes:
 worker-status:
 	@$(WORKER_SCRIPT) display-worker-status
 
+.PHONY: delete-worker
+delete-worker:
+	@if [ -z "$(WORKER_NAME)" ]; then \
+		echo "ERROR: WORKER_NAME not specified"; \
+		echo "Usage: make delete-worker WORKER_NAME=<bmh-name|machine-name>"; \
+		echo ""; \
+		echo "Examples:"; \
+		echo "  make delete-worker WORKER_NAME=nvd-srv-27       (BMH name)"; \
+		echo "  make delete-worker WORKER_NAME=worker-dpu-k9dgj (Machine name)"; \
+		exit 1; \
+	fi
+	@echo "================================================================================"
+	@echo "Deleting worker: $(WORKER_NAME)"
+	@echo "================================================================================"
+	@$(WORKER_SCRIPT) delete-worker $(WORKER_NAME)
+	@echo ""
+	@echo "================================================================================"
+	@echo "Worker deletion completed!"
+	@echo "Run 'make worker-status' to verify."
+	@echo "================================================================================"
+
 .PHONY: approve-worker-csrs
 approve-worker-csrs:
 	@$(WORKER_SCRIPT) approve-worker-csrs
@@ -445,6 +466,7 @@ help:
 	@echo "  configure-flannel - Deploy flannel IPAM controller for automatic podCIDR assignment"
 	@echo "  add-worker-nodes  - Provision worker nodes via BMO/Redfish (uses WORKER_* env vars)"
 	@echo "  worker-status     - Display provisioning status for all configured workers"
+	@echo "  delete-worker     - Delete a worker (usage: make delete-worker WORKER_NAME=<name>)"
 	@echo "  approve-worker-csrs - Approve pending CSRs (one-time, for manual use)"
 	@echo "  deploy-csr-approver - Deploy CSR auto-approver CronJob for host cluster workers"
 	@echo "  delete-csr-approver - Remove CSR auto-approver from host cluster"

--- a/scripts/worker.sh
+++ b/scripts/worker.sh
@@ -280,7 +280,7 @@ delete_worker() {
         # Get Machine consuming this BMH
         machine_name=$(oc get machines.machine.openshift.io -n openshift-machine-api -o json 2>/dev/null | \
             jq -r --arg bmh "$bmh_name" \
-            '.items[] | select(.metadata.annotations."metal3.io/BareMetalHost" // "" | endswith($bmh)) | .metadata.name' 2>/dev/null | head -1)
+            '.items[] | select((.metadata.annotations."metal3.io/BareMetalHost" // "" | split("/") | last) == $bmh) | .metadata.name' 2>/dev/null | head -1)
 
     # Check if it's a Machine name
     elif oc get machines.machine.openshift.io -n openshift-machine-api "$input_name" &>/dev/null; then

--- a/scripts/worker.sh
+++ b/scripts/worker.sh
@@ -215,6 +215,150 @@ delete_csr_auto_approver() {
     log "INFO" "CSR auto-approver removed"
 }
 
+# Helper function to decrease MachineSet replica count
+decrease_machineset_replicas() {
+    log "INFO" "Updating MachineSet replica count to prevent recreation..."
+    local current_replicas
+    current_replicas=$(oc get machinesets.machine.openshift.io worker-dpu -n openshift-machine-api -o jsonpath='{.spec.replicas}' 2>/dev/null || echo "0")
+
+    if [[ "$current_replicas" -gt 0 ]]; then
+        local new_replicas=$((current_replicas - 1))
+        log "INFO" "Decreasing MachineSet replicas: $current_replicas → $new_replicas"
+        oc patch machinesets.machine.openshift.io worker-dpu -n openshift-machine-api --type=merge -p "{\"spec\":{\"replicas\":$new_replicas}}"
+    else
+        log "WARN" "MachineSet worker-dpu has 0 replicas or not found"
+    fi
+}
+
+# Helper function to delete BMH with automated cleaning disabled
+delete_bmh_with_cleanup() {
+    local bmh_name="$1"
+
+    if oc get bmh -n openshift-machine-api "$bmh_name" &>/dev/null; then
+        log "INFO" "Disabling automated cleaning for BMH: $bmh_name (to skip IPA reboot)"
+        oc patch bmh "$bmh_name" -n openshift-machine-api -p '{"spec":{"automatedCleaningMode":"disabled"}}' --type=merge || \
+            log "WARN" "Failed to disable automated cleaning, continuing..."
+
+        log "INFO" "Deleting BareMetalHost: $bmh_name"
+        oc delete bmh -n openshift-machine-api "$bmh_name" --wait=false
+
+        log "INFO" "Waiting for BMH deletion (this may take up to 15 minutes)..."
+        retry 60 15 bash -c "! oc get bmh -n openshift-machine-api '$bmh_name' &>/dev/null" || \
+            log "WARN" "BMH $bmh_name deletion still in progress..."
+
+        log "INFO" "BMC secret will be automatically deleted (ownerReference to BMH)"
+    else
+        log "INFO" "BareMetalHost $bmh_name not found, skipping"
+    fi
+}
+
+# Helper function to warn about manual node deletion
+warn_manual_node_deletion() {
+    log "WARN" "*** IMPORTANT: You must manually delete the OpenShift Node object ***"
+    log "WARN" "*** Run: oc get nodes (find the node) then: oc delete node <node-name> ***"
+}
+
+delete_worker() {
+    local input_name="${1:-}"
+    [[ -z "$input_name" ]] && { log "ERROR" "Worker name required. Usage: $0 delete-worker <bmh-name|machine-name>"; return 1; }
+
+    get_kubeconfig
+
+    log "INFO" "Identifying worker type for: $input_name"
+
+    # Try to identify what type of name was provided and find the BMH name
+    local bmh_name=""
+    local machine_name=""
+
+    # Check if it's a BMH name
+    if oc get bmh -n openshift-machine-api "$input_name" &>/dev/null; then
+        bmh_name="$input_name"
+        log "INFO" "Identified as BareMetalHost: $bmh_name"
+
+        # Get Machine consuming this BMH
+        machine_name=$(oc get machines.machine.openshift.io -n openshift-machine-api -o json 2>/dev/null | \
+            jq -r --arg bmh "$bmh_name" \
+            '.items[] | select(.metadata.annotations."metal3.io/BareMetalHost" // "" | endswith($bmh)) | .metadata.name' 2>/dev/null | head -1)
+
+    # Check if it's a Machine name
+    elif oc get machines.machine.openshift.io -n openshift-machine-api "$input_name" &>/dev/null; then
+        machine_name="$input_name"
+        log "INFO" "Identified as Machine: $machine_name"
+
+        # Get BMH from Machine annotation
+        bmh_name=$(oc get machines.machine.openshift.io -n openshift-machine-api "$machine_name" -o json 2>/dev/null | \
+            jq -r '.metadata.annotations."metal3.io/BareMetalHost" // ""' | sed 's|.*/||' 2>/dev/null || true)
+
+    else
+        log "ERROR" "Could not find BareMetalHost or Machine named: $input_name"
+        return 1
+    fi
+
+    log "INFO" "Worker mapping - BMH: ${bmh_name:-none}, Machine: ${machine_name:-none}"
+
+    [[ -z "$bmh_name" ]] && { log "ERROR" "Could not determine BareMetalHost name"; return 1; }
+
+    # Find worker index and check if it's a DPU worker
+    local worker_index=""
+    local is_dpu="false"
+    for i in $(seq 1 "${WORKER_COUNT:-0}"); do
+        local name_var="WORKER_${i}_NAME"
+        if [[ "${!name_var}" == "$bmh_name" ]]; then
+            worker_index=$i
+            local dpu_var="WORKER_${i}_DPU"
+            is_dpu="${!dpu_var:-true}"
+            break
+        fi
+    done
+
+    if [[ -z "$worker_index" ]]; then
+        log "WARN" "Worker $bmh_name not found in environment variables"
+        # Try to detect if it's DPU by checking if Machine has the dpu-capable selector
+        if [[ -n "$machine_name" ]]; then
+            local has_dpu_label
+            has_dpu_label=$(oc get machines.machine.openshift.io -n openshift-machine-api "$machine_name" -o json 2>/dev/null | \
+                jq -r '.spec.providerSpec.value.hostSelector.matchLabels."dpu-capable" // "false"')
+            [[ "$has_dpu_label" == "true" ]] && is_dpu="true"
+        fi
+    fi
+
+    log "INFO" "Deleting worker: $bmh_name (DPU: $is_dpu)"
+
+    # Handle DPU workers (managed by MachineSet)
+    if [[ "$is_dpu" == "true" ]]; then
+        log "INFO" "DPU worker detected, managing Machine and MachineSet..."
+
+        # Use the machine_name we already found during identification
+        if [[ -n "$machine_name" ]]; then
+            log "INFO" "Deleting Machine: $machine_name (will trigger BMH deprovisioning)"
+            oc delete machines.machine.openshift.io -n openshift-machine-api "$machine_name" --wait=false
+
+            # Immediately decrease replica count to prevent MachineSet from recreating
+            decrease_machineset_replicas
+
+            log "INFO" "Waiting for Machine deletion (this may take up to 15 minutes)..."
+            retry 60 15 bash -c "! oc get machines.machine.openshift.io -n openshift-machine-api '$machine_name' &>/dev/null" || \
+                log "WARN" "Machine $machine_name deletion still in progress..."
+        else
+            log "WARN" "No Machine found associated with BMH $bmh_name"
+            # Still decrease replica count even if Machine not found
+            decrease_machineset_replicas
+        fi
+
+        # Delete the BMH (disable automated cleaning first to skip IPA boot)
+        delete_bmh_with_cleanup "$bmh_name"
+        warn_manual_node_deletion
+
+    # Handle regular (non-DPU) workers
+    else
+        log "INFO" "Regular worker detected (no MachineSet management)"
+        delete_bmh_with_cleanup "$bmh_name"
+        warn_manual_node_deletion
+    fi
+
+    log "INFO" "Worker $bmh_name deletion completed"
+}
+
 # Command dispatcher
 case "${1:-}" in
     provision-all-workers) provision_all_workers ;;
@@ -224,8 +368,9 @@ case "${1:-}" in
     apply-short-worker-hostnames) apply_short_worker_hostnames ;;
     deploy-csr-auto-approver) deploy_csr_auto_approver ;;
     delete-csr-auto-approver) delete_csr_auto_approver ;;
+    delete-worker) delete_worker "${2:-}" ;;
     *)
-        echo "Usage: $0 {provision-all-workers|approve-worker-csrs|display-worker-status|display-manual-csr-instructions|apply-short-worker-hostnames|deploy-csr-auto-approver|delete-csr-auto-approver}"
+        echo "Usage: $0 {provision-all-workers|approve-worker-csrs|display-worker-status|display-manual-csr-instructions|apply-short-worker-hostnames|deploy-csr-auto-approver|delete-csr-auto-approver|delete-worker <bmh-name|machine-name>}"
         exit 1
         ;;
 esac

--- a/scripts/worker.sh
+++ b/scripts/worker.sh
@@ -330,9 +330,16 @@ delete_worker() {
     if [[ "$is_dpu" == "true" ]]; then
         log "INFO" "DPU worker detected, managing Machine and MachineSet..."
 
-        # Use the machine_name we already found during identification
+        # STEP 1: Disable automated cleaning on BMH FIRST (before triggering any deprovisioning)
+        if oc get bmh -n openshift-machine-api "$bmh_name" &>/dev/null; then
+            log "INFO" "Disabling automated cleaning for BMH: $bmh_name (to skip IPA reboot)"
+            oc patch bmh "$bmh_name" -n openshift-machine-api -p '{"spec":{"automatedCleaningMode":"disabled"}}' --type=merge || \
+                log "WARN" "Failed to disable automated cleaning, continuing..."
+        fi
+
+        # STEP 2 & 3: Delete specific Machine and immediately decrease replicas (minimize race window)
         if [[ -n "$machine_name" ]]; then
-            log "INFO" "Deleting Machine: $machine_name (will trigger BMH deprovisioning)"
+            log "INFO" "Deleting Machine: $machine_name and decreasing MachineSet replicas"
             oc delete machines.machine.openshift.io -n openshift-machine-api "$machine_name" --wait=false
 
             # Immediately decrease replica count to prevent MachineSet from recreating
@@ -349,8 +356,22 @@ delete_worker() {
             decrease_machineset_replicas
         fi
 
-        # Delete the BMH (disable automated cleaning first to skip IPA boot)
-        delete_bmh_with_cleanup "$bmh_name"
+        # STEP 4: Delete BMH if it still exists (cleaning already disabled in step 1)
+        if oc get bmh -n openshift-machine-api "$bmh_name" &>/dev/null; then
+            log "INFO" "Deleting BareMetalHost: $bmh_name"
+            oc delete bmh -n openshift-machine-api "$bmh_name" --wait=false
+
+            log "INFO" "Waiting for BMH deletion (this may take up to 15 minutes)..."
+            if ! retry 60 15 bash -c "! oc get bmh -n openshift-machine-api '$bmh_name' &>/dev/null"; then
+                log "ERROR" "Timed out waiting for BMH $bmh_name deletion"
+                return 1
+            fi
+
+            log "INFO" "BMC secret will be automatically deleted (ownerReference to BMH)"
+        else
+            log "INFO" "BareMetalHost $bmh_name already deleted (consumed by Machine)"
+        fi
+
         warn_manual_node_deletion
 
     # Handle regular (non-DPU) workers

--- a/scripts/worker.sh
+++ b/scripts/worker.sh
@@ -243,8 +243,10 @@ delete_bmh_with_cleanup() {
         oc delete bmh -n openshift-machine-api "$bmh_name" --wait=false
 
         log "INFO" "Waiting for BMH deletion (this may take up to 15 minutes)..."
-        retry 60 15 bash -c "! oc get bmh -n openshift-machine-api '$bmh_name' &>/dev/null" || \
-            log "WARN" "BMH $bmh_name deletion still in progress..."
+        if ! retry 60 15 bash -c "! oc get bmh -n openshift-machine-api '$bmh_name' &>/dev/null"; then
+            log "ERROR" "Timed out waiting for BMH $bmh_name deletion"
+            return 1
+        fi
 
         log "INFO" "BMC secret will be automatically deleted (ownerReference to BMH)"
     else
@@ -337,8 +339,10 @@ delete_worker() {
             decrease_machineset_replicas
 
             log "INFO" "Waiting for Machine deletion (this may take up to 15 minutes)..."
-            retry 60 15 bash -c "! oc get machines.machine.openshift.io -n openshift-machine-api '$machine_name' &>/dev/null" || \
-                log "WARN" "Machine $machine_name deletion still in progress..."
+            if ! retry 60 15 bash -c "! oc get machines.machine.openshift.io -n openshift-machine-api '$machine_name' &>/dev/null"; then
+                log "ERROR" "Timed out waiting for Machine $machine_name deletion"
+                return 1
+            fi
         else
             log "WARN" "No Machine found associated with BMH $bmh_name"
             # Still decrease replica count even if Machine not found


### PR DESCRIPTION
- Add delete_worker() function to scripts/worker.sh
- Support deletion by BMH name or Machine name
- Handle both DPU workers (with MachineSet) and regular workers
- Automatically decrease MachineSet replica count for DPU workers
- Disable automated cleaning to skip IPA reboot during deletion
- Use fully qualified resource names (machines.machine.openshift.io)
- Wait up to 15 minutes for Machine and BMH deletion
- Add 'make delete-worker WORKER_NAME=<name>' target
- Warn user to manually delete OpenShift Node object

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `delete-worker` workflow to remove a worker by BareMetalHost or Machine name (requires `WORKER_NAME`).
  * For DPU-capable workers: disables host automation, deletes the associated Machine when present, and reduces MachineSet replicas to avoid immediate recreation.
  * For non-DPU workers: disables host automation and performs host cleanup deletion.
  * Note: The OpenShift Node must still be deleted manually after this operation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->