### PR TITLE
Added early mlx5_core driver bind in case it was not auto-loaded

### DIFF
--- a/manifests/cluster-installation/99-dpu-worker-configuration.yaml
+++ b/manifests/cluster-installation/99-dpu-worker-configuration.yaml
@@ -25,6 +25,11 @@ spec:
           mode: 0644
           overwrite: true
           path: "/etc/NetworkManager/conf.d/unmanage-ovnk-interface.conf"
+        - contents:
+            source: data:text/plain;charset=utf-8;base64,<BASE64_BIND_MLX5_DRIVER>
+          mode: 0755
+          overwrite: true
+          path: /usr/local/bin/bind-mlx5-driver.sh
     systemd:
       units:
         - contents: |
@@ -45,6 +50,23 @@ spec:
             WantedBy=multi-user.target
           enabled: true
           name: nmstate-bridge.service
+        - contents: |
+            [Unit]
+            Description=Bind Mellanox/BlueField devices to mlx5_core driver
+            After=systemd-modules-load.service
+            Before=NetworkManager.service nmstate-bridge.service crio.service kubelet.service
+
+            [Service]
+            Type=oneshot
+            ExecStart=/usr/local/bin/bind-mlx5-driver.sh
+            RemainAfterExit=yes
+            TimeoutStartSec=150s
+            RestartSec=10
+
+            [Install]
+            WantedBy=multi-user.target
+          enabled: true
+          name: bind-mlx5-driver.service
         - name: ovs-configuration.service
           enabled: false
         - name: openvswitch.service

--- a/manifests/cluster-installation/machineconfig-files/bind_mlx5_driver.sh
+++ b/manifests/cluster-installation/machineconfig-files/bind_mlx5_driver.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+if [ ! -d /sys/bus/pci/drivers/mlx5_core ]; then
+  echo "mlx5_core driver not loaded. Attempting modprobe..."
+  if ! modprobe mlx5_core; then
+    echo "ERROR: Failed to load mlx5_core driver." >&2
+    exit 1
+  fi
+fi
+
+VENDOR_MELLANOX="0x15b3"
+
+for dev_path in /sys/bus/pci/devices/*; do
+  [[ -f "$dev_path/vendor" ]] || continue
+  [[ "$(< "$dev_path/vendor")" == "$VENDOR_MELLANOX" ]] || continue
+  full_id=$(basename "$dev_path")
+
+  if [ ! -e "$dev_path/driver" ]; then
+    echo "Device $full_id has no driver. Attempting to bind mlx5_core..."
+
+    echo "$full_id" >/sys/bus/pci/drivers/mlx5_core/bind
+
+    if [ -e "$dev_path/driver" ] && \
+       [ "$(basename "$(readlink "$dev_path/driver")")" = "mlx5_core" ]; then
+      echo "Successfully bound $full_id to mlx5_core."
+    else
+      echo "ERROR: Failed to bind $full_id to mlx5_core." >&2
+    fi
+  else
+    current=$(basename "$(readlink "$dev_path/driver")")
+    echo "Device $full_id already bound to: $current"
+  fi
+done

--- a/scripts/manifests.sh
+++ b/scripts/manifests.sh
@@ -128,10 +128,11 @@ update_worker_manifest() {
     fi
 
     local mc_files_dir="$MANIFESTS_DIR/cluster-installation/machineconfig-files"
-    local b64_bridge b64_routing b64_unmanage
+    local b64_bridge b64_routing b64_unmanage b64_bind_mlx5
     b64_bridge=$(base64 -w 0 < "$mc_files_dir/apply-nmstate-bridge.sh")
     b64_routing=$(base64 -w 0 < "$mc_files_dir/configure-p0-routing.sh")
     b64_unmanage=$(base64 -w 0 < "$mc_files_dir/unmanage-ovnk-interface.conf")
+    b64_bind_mlx5=$(base64 -w 0 < "$mc_files_dir/bind_mlx5_driver.sh")
 
     update_file_multi_replace \
             "$MANIFESTS_DIR/cluster-installation/99-dpu-worker-configuration.yaml" \
@@ -139,7 +140,8 @@ update_worker_manifest() {
             "<NODES_MTU>" "$mtu" \
             "<BASE64_APPLY_NMSTATE_BRIDGE>" "$b64_bridge" \
             "<BASE64_CONFIGURE_P0_ROUTING>" "$b64_routing" \
-            "<BASE64_UNMANAGE_OVNK_INTERFACE>" "$b64_unmanage"
+            "<BASE64_UNMANAGE_OVNK_INTERFACE>" "$b64_unmanage" \
+            "<BASE64_BIND_MLX5_DRIVER>" "$b64_bind_mlx5"
 }
 
 function deploy_core_operator_sources() {


### PR DESCRIPTION
There are some instances and edge cases where the host OS has booted and did not assign the BF-3 card to the `mlx5_core` kernel module.

This PR adds an early systemd service that binds all BF-3 cards that do not have an active kernel module for them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * DPU worker nodes now automatically bind Mellanox/BlueField devices to the mlx5_core driver at boot via an installed startup script and systemd unit, ensuring the driver is in place before networking, container runtime, and kubelet services start.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rh-ecosystem-edge/openshift-dpf/pull/175)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->