### PR TITLE
fix: expand lvirt_install inline in _create_vm

### DIFF
--- a/scripts/vm.sh
+++ b/scripts/vm.sh
@@ -66,7 +66,8 @@ _delete_vms_by_prefix() {
 _create_vm() {
     local vm_name="$1" ram="$2" vcpus="$3" disk1="$4" disk2="$5" network_arg="$6"
     log "INFO" "Starting VM creation for $vm_name..."
-    nohup lvirt_install --name "$vm_name" --memory "$ram" \
+    # nohup cannot call shell functions — expand lvirt_install inline
+    nohup virt-install --connect "${LIBVIRT_URI}" --name "$vm_name" --memory "$ram" \
             --vcpus "$vcpus" \
             --os-variant=rhel9.4 \
             --disk path="${DISK_PATH}/${vm_name}-disk1.qcow2",size="${disk1}" \


### PR DESCRIPTION
Shell functions cannot be invoked via background process wrappers. The `lvirt_install()` wrapper was introduced in PR #166 but `_create_vm()` calls it in a way that looks for an executable in $PATH — not a shell function.

This expands the function call to the underlying `virt-install --connect "${LIBVIRT_URI}"` invocation directly, fixing VM creation in both local and remote libvirt modes.

— Lyra


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved virtual machine creation process to more reliably background the initialization step, ensuring the command executes correctly without unexpected shell function handling issues.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rh-ecosystem-edge/openshift-dpf/pull/176)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->