### PR TITLE
fix: default SSH key to Ed25519 — it's 2026, we've moved on

### DIFF
--- a/ci/env.defaults
+++ b/ci/env.defaults
@@ -18,7 +18,7 @@ MANIFESTS_DIR=${MANIFESTS_DIR:-manifests}
 GENERATED_DIR=${GENERATED_DIR:-manifests/generated}
 POST_INSTALL_DIR=${POST_INSTALL_DIR:-manifests/post-installation}
 GENERATED_POST_INSTALL_DIR=${GENERATED_POST_INSTALL_DIR:-manifests/generated/post-install}
-SSH_KEY=${SSH_KEY:-~/.ssh/id_rsa.pub}
+SSH_KEY=${SSH_KEY:-~/.ssh/id_ed25519.pub}
 
 # DPF Configuration
 DPF_VERSION=${DPF_VERSION:-26.4.0-c6520937}

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -32,7 +32,7 @@ OPENSHIFT_VERSION=4.20.0                 # Supported versions: 4.20.x
 # Credentials (Required)
 OPENSHIFT_PULL_SECRET=openshift_pull.json   # Red Hat pull secret
 DPF_PULL_SECRET=pull-secret.txt             # NGC registry credentials
-SSH_KEY=~/.ssh/id_rsa                       # SSH key for access
+SSH_KEY=~/.ssh/id_ed25519                   # SSH key for access
 ```
 
 ### VM Resources (Adjust for your hardware)

--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -133,11 +133,14 @@ Generate an SSH key for cluster access:
 
 ```bash
 # Generate new SSH key (if you don't have one)
-ssh-keygen -t rsa -f ~/.ssh/id_rsa -N ""
+ssh-keygen -t ed25519 -f ~/.ssh/id_ed25519 -N ""
 
 # Verify public key exists
-ls -la ~/.ssh/id_rsa.pub
+ls -la ~/.ssh/id_ed25519.pub
 ```
+
+> **Note**: Ed25519 is the recommended key type. RSA keys (`~/.ssh/id_rsa.pub`) are still
+> supported — set `SSH_KEY=~/.ssh/id_rsa.pub` in your `.env` if that's what you have.
 
 ## Step 4: Configure Environment
 


### PR DESCRIPTION
## What

The default SSH key path was `~/.ssh/id_rsa.pub`. It's now `~/.ssh/id_ed25519.pub`.

## Why

Because it's 2026 and we're not cavemen.

Ed25519 has been the recommended SSH key type since **OpenSSH 6.5**, which shipped in **January 2014**. That's over twelve years ago. Twelve. The `ssh-keygen` man page has been nudging people toward Ed25519 for longer than some of our interns have been writing code.

RSA served us well. It had a good run. But defaulting to it in new projects in 2026 is like defaulting to `python2` — technically still works, nobody should be doing it, and it makes people quietly judge your repo.

### Ed25519 vs RSA, for the uninitiated:

| | Ed25519 | RSA-4096 |
|---|---|---|
| Key size | 32 bytes | 512 bytes |
| Signature speed | ~8x faster | slow by comparison |
| Security margin | ~128-bit equivalent | ~128-bit (at 3072+) |
| Year introduced | 2014 | 1977 |
| Vibe | modern, compact, fast | your grandfather's key algorithm |

### What about existing users?

Nothing breaks. `SSH_KEY` is already an env var — anyone with RSA keys just sets `SSH_KEY=~/.ssh/id_rsa.pub` in their `.env` and carries on. This only changes the *default* for new setups.

Added a note in the getting-started guide so nobody panics.

### Note on `dpf.sh`

The `--from-file=id_rsa.pub=${SSH_KEY}` in `dpf.sh` is a **Kubernetes secret key name**, not a file path reference. It stays as `id_rsa.pub` because that's what the HCP provisioner operator (and upstream HyperShift) expects as the secret data key. Renaming it would break the operator's secret validator. The irony of a modern Ed25519 key living under a key named `id_rsa.pub` in a K8s secret is not lost on me, but that's an upstream problem.

## Files changed

- `ci/env.defaults` — default path: `~/.ssh/id_ed25519.pub`
- `docs/user-guide/configuration.md` — example updated
- `docs/user-guide/getting-started.md` — keygen command updated to `-t ed25519`, added RSA fallback note

— Lyra

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default SSH key authentication from RSA to Ed25519.

* **Documentation**
  * Updated Getting Started and Configuration guides to recommend Ed25519 key generation.
  * Added guidance that RSA keys remain supported and can be configured manually if needed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rh-ecosystem-edge/openshift-dpf/pull/179?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->