### PR TITLE
Bump dts to 1.25.5 doca3.4.0 

### DIFF
--- a/ci/env.defaults
+++ b/ci/env.defaults
@@ -77,7 +77,7 @@ HBN_IMAGE_TAG=${HBN_IMAGE_TAG:-3.2.0-doca3.2.0}
 # DTS Service Configuration
 DTS_HELM_REPO_URL=${DTS_HELM_REPO_URL:-https://helm.ngc.nvidia.com/nvidia/doca}
 DTS_HELM_CHART_VERSION=${DTS_HELM_CHART_VERSION:-1.25.5}
-DTS_IMAGE=${DTS_IMAGE:-nvcr.io/nvidia/doca/doca_telemetry:1.25.5-doca3.4.0-host}
+DTS_IMAGE=${DTS_IMAGE:-nvcr.io/nvidia/doca/doca_telemetry:1.25.5-doca3.4.0}
 
 # VM Configuration
 LIBVIRT_HOST=${LIBVIRT_HOST:-}

--- a/ci/env.defaults
+++ b/ci/env.defaults
@@ -76,8 +76,8 @@ HBN_IMAGE_TAG=${HBN_IMAGE_TAG:-3.2.0-doca3.2.0}
 
 # DTS Service Configuration
 DTS_HELM_REPO_URL=${DTS_HELM_REPO_URL:-https://helm.ngc.nvidia.com/nvidia/doca}
-DTS_HELM_CHART_VERSION=${DTS_HELM_CHART_VERSION:-1.22.1}
-DTS_IMAGE=${DTS_IMAGE:-nvcr.io/nvidia/doca/doca_telemetry:1.21.5-doca3.0.0}
+DTS_HELM_CHART_VERSION=${DTS_HELM_CHART_VERSION:-1.25.5}
+DTS_IMAGE=${DTS_IMAGE:-nvcr.io/nvidia/doca/doca_telemetry:1.25.5-doca3.4.0-host}
 
 # VM Configuration
 LIBVIRT_HOST=${LIBVIRT_HOST:-}


### PR DESCRIPTION
* Bump default DTS Helm chart from 1.22.1 to 1.25.5
* Bump default DTS image to `nvcr.io/nvidia/doca/doca_telemetry:1.25.5-doca3.4.0`
* Aligns openshift-dpf defaults with current NGC DOCA 3.4.0 release

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated DTS service to version 1.25.5 with corresponding image update to the latest compatible release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->