### PR TITLE
fix: deploy LVMS by default when STORAGE_TYPE=lvm

### DIFF
--- a/scripts/cluster.sh
+++ b/scripts/cluster.sh
@@ -391,8 +391,8 @@ function start_cluster_installation() {
         log "INFO" "STORAGE_TYPE=odf detected. Deploying LSO and ODF..."
         deploy_lso
         deploy_odf
-    elif [[ "${OLM_WORKAROUND}" == "true" ]]; then
-        log "INFO" "OLM_WORKAROUND=true: deploying LVM via subscription (using catalog ${CATALOG_SOURCE_NAME})"
+    else
+        log "INFO" "Deploying LVMS (STORAGE_TYPE=${STORAGE_TYPE})..."
         deploy_lvm
     fi
 }


### PR DESCRIPTION
## Bug

Running `make all` on a default single-node setup results in the `etcd-0` pod stuck in Pending forever. The PVC `data-etcd-0` references StorageClass `lvms-vg1`, but LVMS is never installed, so the PVC can't bind.

## Root Cause

In `scripts/cluster.sh`, the `start_cluster_installation()` function handles post-install storage deployment with a conditional block that only deploys LVMS when `OLM_WORKAROUND=true`:

```bash
if [ "${SKIP_DEPLOY_STORAGE}" = "true" ]; then
    # validates existing storage classes
elif [ "${STORAGE_TYPE}" == "odf" ]; then
    deploy_lso
    deploy_odf
elif [[ "${OLM_WORKAROUND}" == "true" ]]; then
    deploy_lvm
fi
```

The default path (`STORAGE_TYPE=lvm`, `OLM_WORKAROUND` unset) falls through without deploying anything. Meanwhile, `scripts/env.sh` correctly defaults `ETCD_STORAGE_CLASS` to `lvms-vg1` for the LVM case — but the operator that provides that StorageClass is never installed.

> **Note:** CI sets `OLM_WORKAROUND=true` by default (`ci/env.defaults`), so this bug only manifests in local/non-CI runs where the variable is unset.

## Fix

Replace the `OLM_WORKAROUND`-gated `elif` with an `else` branch so LVMS is deployed for any non-ODF, non-skipped storage configuration. The `deploy_lvm()` function already uses `CATALOG_SOURCE_NAME` internally, so the OLM workaround catalog source is picked up automatically when `OLM_WORKAROUND=true`.

## Workaround

Run `make deploy-lvms` before or after `make all`, then delete the stuck PVC/pod so they get recreated.

— Lyra 🤖