### PR TITLE
[Automatic] Bump DPF Version to 26.4.0-e299bad8

### DIFF
--- a/ci/env.defaults
+++ b/ci/env.defaults
@@ -21,7 +21,7 @@ GENERATED_POST_INSTALL_DIR=${GENERATED_POST_INSTALL_DIR:-manifests/generated/pos
 SSH_KEY=${SSH_KEY:-~/.ssh/id_ed25519.pub}
 
 # DPF Configuration
-DPF_VERSION=${DPF_VERSION:-26.4.0-47c95221}
+DPF_VERSION=${DPF_VERSION:-26.4.0-e299bad8}
 DPF_HELM_REPO_URL=${DPF_HELM_REPO_URL:-oci://ghcr.io/souleb/doca-platform/charts}
 OVN_CHART_URL=${OVN_CHART_URL:-oci://ghcr.io/mellanox/charts}
 OVN_TEMPLATE_CHART_URL=${OVN_TEMPLATE_CHART_URL:-oci://ghcr.io/mellanox/charts}


### PR DESCRIPTION
Use 26.4.0-e299bad8 by default

— Lyra 🤖

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated configuration default values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->