### PR TITLE
[Automatic] Bump DPF Version to 26.4.0-e299bad8

### DIFF
--- a/ci/env.defaults
+++ b/ci/env.defaults
@@ -6,7 +6,7 @@
 # Syntax: ${VAR:-default} means "use default if VAR is unset or empty"
 
 # Cluster Configuration
-OPENSHIFT_VERSION=${OPENSHIFT_VERSION:-4.22.0-rc.3}
+OPENSHIFT_VERSION=${OPENSHIFT_VERSION:-4.22.0}
 OLM_WORKAROUND=${OLM_WORKAROUND:-true}
 
 # Bridge Configuration
@@ -21,7 +21,7 @@ GENERATED_POST_INSTALL_DIR=${GENERATED_POST_INSTALL_DIR:-manifests/generated/pos
 SSH_KEY=${SSH_KEY:-~/.ssh/id_ed25519.pub}
 
 # DPF Configuration
-DPF_VERSION=${DPF_VERSION:-26.4.0-7c6fb69e}
+DPF_VERSION=${DPF_VERSION:-26.4.0-e299bad8}
 DPF_HELM_REPO_URL=${DPF_HELM_REPO_URL:-oci://ghcr.io/souleb/doca-platform/charts}
 OVN_CHART_URL=${OVN_CHART_URL:-oci://ghcr.io/mellanox/charts}
 OVN_TEMPLATE_CHART_URL=${OVN_TEMPLATE_CHART_URL:-oci://ghcr.io/mellanox/charts}
@@ -76,8 +76,8 @@ HBN_IMAGE_TAG=${HBN_IMAGE_TAG:-3.2.0-doca3.2.0}
 
 # DTS Service Configuration
 DTS_HELM_REPO_URL=${DTS_HELM_REPO_URL:-https://helm.ngc.nvidia.com/nvidia/doca}
-DTS_HELM_CHART_VERSION=${DTS_HELM_CHART_VERSION:-1.22.1}
-DTS_IMAGE=${DTS_IMAGE:-nvcr.io/nvidia/doca/doca_telemetry:1.21.5-doca3.0.0}
+DTS_HELM_CHART_VERSION=${DTS_HELM_CHART_VERSION:-1.25.5}
+DTS_IMAGE=${DTS_IMAGE:-nvcr.io/nvidia/doca/doca_telemetry:1.25.5-doca3.4.0}
 
 # VM Configuration
 LIBVIRT_HOST=${LIBVIRT_HOST:-}


### PR DESCRIPTION
Use 26.4.0-e299bad8 by default

— Lyra 🤖

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated default version pins: OpenShift advanced to stable 4.22.0 release
  * Upgraded DTS Helm Chart and image to version 1.25.5 with DOCA 3.4.0
  * Updated DPF version

<!-- end of auto-generated comment: release notes by coderabbit.ai -->