### PR TITLE
Update DPF version and helm repo to OCP cherry-picks build

### DIFF
--- a/ci/env.defaults
+++ b/ci/env.defaults
@@ -21,8 +21,8 @@ GENERATED_POST_INSTALL_DIR=${GENERATED_POST_INSTALL_DIR:-manifests/generated/pos
 SSH_KEY=${SSH_KEY:-~/.ssh/id_ed25519.pub}
 
 # DPF Configuration
-DPF_VERSION=${DPF_VERSION:-26.4.0-47c95221}
-DPF_HELM_REPO_URL=${DPF_HELM_REPO_URL:-oci://ghcr.io/souleb/doca-platform/charts}
+DPF_VERSION=${DPF_VERSION:-v26.4-ocp-cherry-picks-0e43ed9c1}
+DPF_HELM_REPO_URL=${DPF_HELM_REPO_URL:-oci://quay.io/itsoiref}
 OVN_CHART_URL=${OVN_CHART_URL:-oci://ghcr.io/mellanox/charts}
 OVN_TEMPLATE_CHART_URL=${OVN_TEMPLATE_CHART_URL:-oci://ghcr.io/mellanox/charts}
 OVN_CHART_VERSION=${OVN_CHART_VERSION:-v26.4.0-ocpbeta}


### PR DESCRIPTION
## Summary
- Update `DPF_VERSION` to `v26.4-ocp-cherry-picks-0e43ed9c1`
- Update `DPF_HELM_REPO_URL` to `oci://quay.io/itsoiref`

Switches the default DPF helm chart source to a build containing OCP-specific cherry-picks for testing.

## Test plan
- [ ] Deploy DPF using the updated defaults and verify operator comes up successfully

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default deployment configuration, including platform version and artifact repository settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->