### PR TITLE
Revert "use 26.4.1 beta releases"

### DIFF
--- a/ci/env.defaults
+++ b/ci/env.defaults
@@ -21,8 +21,8 @@ GENERATED_POST_INSTALL_DIR=${GENERATED_POST_INSTALL_DIR:-manifests/generated/pos
 SSH_KEY=${SSH_KEY:-~/.ssh/id_ed25519.pub}
 
 # DPF Configuration
-DPF_VERSION=${DPF_VERSION:-v26.4.1-beta.1}
-DPF_HELM_REPO_URL=${DPF_HELM_REPO_URL:-oci://ghcr.io/souleb/doca-platform/charts}
+DPF_VERSION=${DPF_VERSION:-v26.4-ocp-cherry-picks-0e43ed9c1}
+DPF_HELM_REPO_URL=${DPF_HELM_REPO_URL:-oci://quay.io/itsoiref}
 OVN_CHART_URL=${OVN_CHART_URL:-oci://ghcr.io/mellanox/charts}
 OVN_TEMPLATE_CHART_URL=${OVN_TEMPLATE_CHART_URL:-oci://ghcr.io/mellanox/charts}
 OVN_CHART_VERSION=${OVN_CHART_VERSION:-v26.4.0-ocpbeta}

--- a/manifests/dpf-installation/dpfoperatorconfig.yaml
+++ b/manifests/dpf-installation/dpfoperatorconfig.yaml
@@ -23,9 +23,6 @@ spec:
     dpuCNIPath: /run/multus/cni/net.d/
     # Configure lib64 path for RHCOS systems
     dpuOpenvSwitchSystemSharedLib64Path: /lib64
-    # Configure linker cache and opt library path for RHCOS systems
-    dpuLinkerCachePath: /etc/ld.so.cache
-    dpuOptLibraryPath: /usr/opt
     # When using OpenShift Multus (default), Flannel needs to install CNI config
     flannelSkipCNIConfigInstallation: false
   provisioningController:


### PR DESCRIPTION
This reverts commit 89073946d89f469460427d226d3f1ae0f76579e8.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default DPF component version to align with latest changes.
  * Migrated helm chart repository configuration to a new registry location.
  * Removed RHCOS-specific linker cache and library path settings from operator configuration defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->