### PR TITLE
Update Bluefield OCP image version to 4.22.0

### DIFF
--- a/ci/env.defaults
+++ b/ci/env.defaults
@@ -115,7 +115,7 @@ BFB_STORAGE_CLASS=${BFB_STORAGE_CLASS:-lvms-vg1}
 BFB_URL=${BFB_URL:-}
 
 # Bluefield image layer
-BLUEFIELD_OCP_IMAGE=${BLUEFIELD_OCP_IMAGE:-quay.io/eelgaev/bluefield-ocp:4.21.0_3.4.0-beta-v2}
+BLUEFIELD_OCP_IMAGE=${BLUEFIELD_OCP_IMAGE:-quay.io/eelgaev/bluefield-ocp:4.22.0_3.4.0-rh10.2}
 
 # Kubeconfig
 KUBECONFIG=${KUBECONFIG:-./kubeconfig}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated BlueField OCP image to version 4.22.0 (previously 4.21.0 beta).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->