### PR TITLE
fix: move `ovnDaemonsetVersion` to `DPUServiceTemplate` and add 1.3.0 for OCP >= 4.22.1

### DIFF
--- a/manifests/post-installation/ovn-configuration.yaml
+++ b/manifests/post-installation/ovn-configuration.yaml
@@ -11,7 +11,6 @@ spec:
         global:
           enableOvnKubeIdentity: false
           imagePullSecretName: "dpf-pull-secret"
-        ovnDaemonsetVersion: "<OVN_DAEMONSET_VERSION>"
         k8sAPIServer: https://<HOST_CLUSTER_API>:6443
         podNetwork: 10.128.0.0/14/23
         serviceNetwork: 172.30.0.0/16

--- a/manifests/post-installation/ovn-template.yaml
+++ b/manifests/post-installation/ovn-template.yaml
@@ -21,5 +21,6 @@ spec:
         enabled: true
         cniBinDir: /var/lib/cni/bin/
         cniConfDir: /run/multus/cni/net.d
+      ovnDaemonsetVersion: "<OVN_DAEMONSET_VERSION>"
       leaseNamespace: "openshift-ovn-kubernetes"
       gatewayOpts: "--gateway-interface=br-dpu"

--- a/scripts/post-install.sh
+++ b/scripts/post-install.sh
@@ -92,6 +92,13 @@ function update_hbn_ovn_manifests() {
             log [INFO] "OVN_KUBERNETES_UTILS_IMAGE_REPO or OVN_KUBERNETES_UTILS_IMAGE_TAG not set, omitting imagedpf section from ovn-template.yaml"
         fi
         
+        local ovn_daemonset_version="1.1.0"
+        if ocp_version_gte "${OPENSHIFT_VERSION}" "4.22.1"; then
+            ovn_daemonset_version="1.3.0"
+        elif ocp_version_gte "${OPENSHIFT_VERSION}" "4.21.9"; then
+            ovn_daemonset_version="1.2.0"
+        fi
+
         # Use update_file_multi_replace for all replacements
         update_file_multi_replace \
             "${POST_INSTALL_DIR}/ovn-template.yaml" \
@@ -102,7 +109,8 @@ function update_hbn_ovn_manifests() {
             "<OVN_KUBERNETES_IMAGE_REPO>" "${OVN_KUBERNETES_IMAGE_REPO}" \
             "<OVN_KUBERNETES_IMAGE_TAG>" "${OVN_KUBERNETES_IMAGE_TAG}" \
             "<OVN_KUBERNETES_UTILS_IMAGES>" "${utils_images_replacement}" \
-            "<OVN_CHART_URL>" "${OVN_CHART_URL}"
+            "<OVN_CHART_URL>" "${OVN_CHART_URL}" \
+            "<OVN_DAEMONSET_VERSION>" "${ovn_daemonset_version}"
     fi
 
     # Update ovn-configuration.yaml for DPUDeployment
@@ -115,20 +123,14 @@ function update_hbn_ovn_manifests() {
             ovn_mtu=1400
         fi
 
-        local ovn_daemonset_version="1.1.0"
-        if ocp_version_gte "${OPENSHIFT_VERSION}" "4.21.9"; then
-            ovn_daemonset_version="1.2.0"
-        fi
-
-        log "INFO" "ovn-configuration will be set with MTU:$ovn_mtu ovnDaemonsetVersion:$ovn_daemonset_version"
+        log "INFO" "ovn-configuration will be set with MTU:$ovn_mtu"
         update_file_multi_replace \
             "${POST_INSTALL_DIR}/ovn-configuration.yaml" \
             "${GENERATED_POST_INSTALL_DIR}/ovn-configuration.yaml" \
             "<HBN_OVN_NETWORK>" "${HBN_OVN_NETWORK}" \
             "<HOST_CLUSTER_API>" "${HOST_CLUSTER_API}" \
             "<DPU_HOST_CIDR>" "${DPU_HOST_CIDR}" \
-            "<NODES_MTU>" "${ovn_mtu}" \
-            "<OVN_DAEMONSET_VERSION>" "${ovn_daemonset_version}"
+            "<NODES_MTU>" "${ovn_mtu}"
     fi
     
     # Update hbn-configuration.yaml 


### PR DESCRIPTION

The `ovnDaemonsetVersion` value belongs in the `DPUServiceTemplate` rather than the `DPUServiceConfiguration`, since it is determined by the OVN image version shipped in the OCP release, and they should be changed in lockstep to prevent a bricked daemonset

OCP 4.22.1 bumped ovnkube.sh to expect version 1.3.0, causing a version mismatch crash loop when the chart still declares 1.2.0.

Note that we're going to tear out `DPUServiceTemplate` from this repo (#183) eventually anyway but the removal from `DPUServiceConfiguration` is still needed and it's nice to have until we merge that PR

Assisted-by: Claude <noreply@anthropic.com>