### PR TITLE
Change csr-auto-approver concurrencyPolicy to Replace

### DIFF
--- a/manifests/worker-provisioning/csr-auto-approver.yaml
+++ b/manifests/worker-provisioning/csr-auto-approver.yaml
@@ -45,6 +45,7 @@ metadata:
   name: csr-auto-approver
   namespace: openshift-machine-api
 spec:
+  concurrencyPolicy: Replace
   schedule: "*/1 * * * *"
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 3


### PR DESCRIPTION
On a 8 day old cluster:
```
kubectl get cronjob csr-auto-approver -n openshift-machine-api
NAME                SCHEDULE      TIMEZONE   SUSPEND   ACTIVE   LAST SCHEDULE   AGE
csr-auto-approver   */1 * * * *   <none>     False     227      52s             8d
```

This was causing the DPU nodes to transition to `NotReady` states.

ps. The default was `Allow`. There is also `Forbid` that we could consider.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the certificate auto-approval schedule to prevent overlapping runs, helping ensure only the latest scheduled job executes at a time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->