### PR TITLE
fix: clear stale br-hbn bridge before recreating it in DPUFlavors

### DIFF
--- a/manifests/post-installation/dpuflavor-1500.yaml
+++ b/manifests/post-installation/dpuflavor-1500.yaml
@@ -60,6 +60,7 @@ spec:
       _ovs-vsctl --may-exist add-br br-sfc
       _ovs-vsctl set bridge br-sfc datapath_type=netdev
       _ovs-vsctl set bridge br-sfc fail_mode=secure
+      _ovs-vsctl --if-exists del-br br-hbn
       _ovs-vsctl --may-exist add-br br-hbn
       _ovs-vsctl set bridge br-hbn datapath_type=netdev
       _ovs-vsctl set bridge br-hbn fail_mode=secure

--- a/manifests/post-installation/dpuflavor-9000.yaml
+++ b/manifests/post-installation/dpuflavor-9000.yaml
@@ -61,6 +61,7 @@ spec:
       _ovs-vsctl --may-exist add-br br-sfc
       _ovs-vsctl set bridge br-sfc datapath_type=netdev
       _ovs-vsctl set bridge br-sfc fail_mode=secure
+      _ovs-vsctl --if-exists del-br br-hbn
       _ovs-vsctl --may-exist add-br br-hbn
       _ovs-vsctl set bridge br-hbn datapath_type=netdev
       _ovs-vsctl set bridge br-hbn fail_mode=secure


### PR DESCRIPTION
The DPUFlavor rawConfigScript creates br-hbn with `add-br` but a stale br-hbn from a prior provisioning can retain leftover interfaces in OVS after the owning pod is deleted, causing connectivity issues on the DPU.

Tear down any existing br-hbn with `del-br --if-exists` immediately before recreating it, so each provisioning starts from a clean bridge. Applies to both the 1500 and 9000 MTU flavors.

Ref: NVBug 6345247

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved network bridge setup by removing any existing `br-hbn` bridge before recreating it, helping avoid conflicts during post-installation configuration.
  * Made bridge reconfiguration more reliable across different DPU flavor setups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->