### PR TITLE
feat: add DTS DPU telemetry dashboards (Grafana + native console)

### DIFF
--- a/manifests/observability/console-dashboards/dts-console-dashboard.yaml
+++ b/manifests/observability/console-dashboards/dts-console-dashboard.yaml
@@ -1,0 +1,151 @@
+---
+# Native OpenShift Console dashboard for DOCA Telemetry Service (DTS).
+#
+# This renders under the OCP console: Observe -> Dashboards -> "DOCA DPU
+# Telemetry (DTS)". It uses NO Grafana — the OpenShift console monitoring
+# plugin reads ConfigMaps in openshift-config-managed labeled
+# console.openshift.io/dashboard="true" and renders the (legacy Grafana)
+# dashboard JSON against the platform Prometheus/Thanos (which includes
+# user-workload monitoring, where DTS metrics land).
+#
+# Schema verified against the cluster's own console dashboards
+# (rows/span layout, datasource "prometheus", panel type "graph").
+# Companion to the richer grafana-operator dashboard
+# (manifests/observability/grafana/dts-grafana-dashboard.yaml).
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: dpf-dts-console-dashboard
+  namespace: openshift-config-managed
+  labels:
+    console.openshift.io/dashboard: "true"
+data:
+  doca-dpu-telemetry-dts.json: |
+    {
+      "title": "DOCA DPU Telemetry (DTS)",
+      "uid": "doca-dpu-telemetry-dts-console",
+      "editable": false,
+      "schemaVersion": 16,
+      "tags": ["dpf", "dpu", "dts", "telemetry"],
+      "timezone": "browser",
+      "time": {"from": "now-1h", "to": "now"},
+      "refresh": "30s",
+      "templating": {"list": []},
+      "rows": [
+        {
+          "title": "PCIe / Link",
+          "showTitle": true,
+          "height": "250px",
+          "panels": [
+            {
+              "type": "graph", "title": "PCIe Link Speed (GT/s)", "span": 6,
+              "datasource": "prometheus", "nullPointMode": "null",
+              "legend": {"show": true},
+              "yaxes": [{"format": "none", "show": true}, {"format": "none", "show": false}],
+              "targets": [
+                {"refId": "A", "format": "time_series", "intervalFactor": 2,
+                 "expr": "current_link_speed", "legendFormat": "{{source}} {{hca}}"}
+              ]
+            },
+            {
+              "type": "graph", "title": "PCIe Link Width (lanes)", "span": 6,
+              "datasource": "prometheus", "nullPointMode": "null",
+              "legend": {"show": true},
+              "yaxes": [{"format": "none", "show": true}, {"format": "none", "show": false}],
+              "targets": [
+                {"refId": "A", "format": "time_series", "intervalFactor": 2,
+                 "expr": "current_link_width", "legendFormat": "{{source}} {{hca}}"}
+              ]
+            }
+          ]
+        },
+        {
+          "title": "Uplink Throughput (p0/p1)",
+          "showTitle": true,
+          "height": "250px",
+          "panels": [
+            {
+              "type": "graph", "title": "Uplink RX (bits/s)", "span": 6,
+              "datasource": "prometheus", "nullPointMode": "null",
+              "legend": {"show": true, "values": true, "avg": true, "max": true, "alignAsTable": true, "rightSide": true},
+              "yaxes": [{"format": "bps", "show": true}, {"format": "bps", "show": false}],
+              "targets": [
+                {"refId": "A", "format": "time_series", "intervalFactor": 2,
+                 "expr": "sum by(source)(rate({__name__=~\"p[01]_eth_rx_bytes\"}[5m])) * 8",
+                 "legendFormat": "{{source}}"}
+              ]
+            },
+            {
+              "type": "graph", "title": "Uplink TX (bits/s)", "span": 6,
+              "datasource": "prometheus", "nullPointMode": "null",
+              "legend": {"show": true, "values": true, "avg": true, "max": true, "alignAsTable": true, "rightSide": true},
+              "yaxes": [{"format": "bps", "show": true}, {"format": "bps", "show": false}],
+              "targets": [
+                {"refId": "A", "format": "time_series", "intervalFactor": 2,
+                 "expr": "sum by(source)(rate({__name__=~\"p[01]_eth_tx_bytes\"}[5m])) * 8",
+                 "legendFormat": "{{source}}"}
+              ]
+            }
+          ]
+        },
+        {
+          "title": "Uplink Packets & Errors",
+          "showTitle": true,
+          "height": "250px",
+          "panels": [
+            {
+              "type": "graph", "title": "Uplink packets/s (rx + tx)", "span": 6,
+              "datasource": "prometheus", "nullPointMode": "null",
+              "legend": {"show": true, "alignAsTable": true, "rightSide": true},
+              "yaxes": [{"format": "pps", "show": true}, {"format": "pps", "show": false}],
+              "targets": [
+                {"refId": "A", "format": "time_series", "intervalFactor": 2,
+                 "expr": "sum by(source)(rate({__name__=~\"p[01]_eth_rx_packets\"}[5m]))",
+                 "legendFormat": "{{source}} rx"},
+                {"refId": "B", "format": "time_series", "intervalFactor": 2,
+                 "expr": "sum by(source)(rate({__name__=~\"p[01]_eth_tx_packets\"}[5m]))",
+                 "legendFormat": "{{source}} tx"}
+              ]
+            },
+            {
+              "type": "graph", "title": "Uplink errors & drops/s", "span": 6,
+              "datasource": "prometheus", "nullPointMode": "null",
+              "legend": {"show": true, "alignAsTable": true, "rightSide": true},
+              "yaxes": [{"format": "cps", "show": true}, {"format": "cps", "show": false}],
+              "targets": [
+                {"refId": "A", "format": "time_series", "intervalFactor": 2,
+                 "expr": "sum by(source)(rate({__name__=~\"p[01]_eth_rx_errors\"}[5m])) + sum by(source)(rate({__name__=~\"p[01]_eth_tx_errors\"}[5m])) + sum by(source)(rate({__name__=~\"p[01]_eth_rx_dropped\"}[5m])) + sum by(source)(rate({__name__=~\"p[01]_eth_tx_dropped\"}[5m])) + sum by(source)(rate({__name__=~\"p[01]_eth_rx_crc_errors\"}[5m]))",
+                 "legendFormat": "{{source}}"}
+              ]
+            }
+          ]
+        },
+        {
+          "title": "NIC Channel Activity",
+          "showTitle": true,
+          "height": "250px",
+          "panels": [
+            {
+              "type": "graph", "title": "NIC channel poll/s", "span": 6,
+              "datasource": "prometheus", "nullPointMode": "null",
+              "legend": {"show": true, "alignAsTable": true, "rightSide": true},
+              "yaxes": [{"format": "cps", "show": true}, {"format": "cps", "show": false}],
+              "targets": [
+                {"refId": "A", "format": "time_series", "intervalFactor": 2,
+                 "expr": "sum by(source)(rate(ch_poll[5m]))", "legendFormat": "{{source}}"}
+              ]
+            },
+            {
+              "type": "graph", "title": "NIC channel events/s", "span": 6,
+              "datasource": "prometheus", "nullPointMode": "null",
+              "legend": {"show": true, "alignAsTable": true, "rightSide": true},
+              "yaxes": [{"format": "cps", "show": true}, {"format": "cps", "show": false}],
+              "targets": [
+                {"refId": "A", "format": "time_series", "intervalFactor": 2,
+                 "expr": "sum by(source)(rate(ch_events[5m]))", "legendFormat": "{{source}}"}
+              ]
+            }
+          ]
+        }
+      ]
+    }

--- a/manifests/observability/grafana/dts-grafana-dashboard.yaml
+++ b/manifests/observability/grafana/dts-grafana-dashboard.yaml
@@ -1,0 +1,191 @@
+---
+# DOCA Telemetry Service (DTS) — DPU hardware telemetry dashboard.
+#
+# Config-only addition to the existing dpf-grafana stack. The DTS DPUService
+# already exports sysfs/ethtool counters on :9189; the doca-telemetry-service
+# ServiceMonitor scrapes them into OpenShift user-workload monitoring, and the
+# GrafanaDatasource "prometheus" (Thanos querier) makes them queryable.
+#
+# This manifest only adds a visualization: a ConfigMap holding the dashboard
+# JSON plus a GrafanaDashboard CR that loads it into the dpf-grafana instance
+# (instanceSelector dashboards=dpf-grafana, same convention as
+# grafana-dashboards.yaml). No DTS/cluster reconfiguration required.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: dpf-dts-grafana-dashboard
+  namespace: dpf-operator-system
+  labels:
+    app.kubernetes.io/part-of: dpf
+data:
+  doca-dpu-telemetry-dts.json: |
+    {
+      "title": "DOCA DPU Telemetry (DTS)",
+      "uid": "doca-dpu-telemetry-dts",
+      "tags": ["dpf", "dpu", "dts", "telemetry"],
+      "timezone": "browser",
+      "schemaVersion": 39,
+      "editable": true,
+      "time": {"from": "now-1h", "to": "now"},
+      "refresh": "30s",
+      "templating": {
+        "list": [
+          {
+            "name": "source",
+            "label": "DPU (source)",
+            "type": "query",
+            "datasource": {"type": "prometheus", "uid": "prometheus"},
+            "query": "label_values(current_link_speed, source)",
+            "refresh": 2,
+            "includeAll": true,
+            "multi": true,
+            "current": {"text": "All", "value": "$__all"},
+            "sort": 1
+          }
+        ]
+      },
+      "panels": [
+        {
+          "type": "stat",
+          "title": "PCIe Link Speed (GT/s)",
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "gridPos": {"h": 4, "w": 6, "x": 0, "y": 0},
+          "fieldConfig": {"defaults": {"unit": "none"}, "overrides": []},
+          "options": {"reduceOptions": {"calcs": ["lastNotNull"]}, "colorMode": "value", "graphMode": "none"},
+          "targets": [
+            {"refId": "A", "datasource": {"type": "prometheus", "uid": "prometheus"},
+             "expr": "current_link_speed{source=~\"$source\"}", "legendFormat": "{{source}} {{hca}}"}
+          ]
+        },
+        {
+          "type": "stat",
+          "title": "PCIe Link Width (lanes)",
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "gridPos": {"h": 4, "w": 6, "x": 6, "y": 0},
+          "fieldConfig": {"defaults": {"unit": "none"}, "overrides": []},
+          "options": {"reduceOptions": {"calcs": ["lastNotNull"]}, "colorMode": "value", "graphMode": "none"},
+          "targets": [
+            {"refId": "A", "datasource": {"type": "prometheus", "uid": "prometheus"},
+             "expr": "current_link_width{source=~\"$source\"}", "legendFormat": "{{source}} {{hca}}"}
+          ]
+        },
+        {
+          "type": "stat",
+          "title": "Max PCIe Link Speed (GT/s)",
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "gridPos": {"h": 4, "w": 6, "x": 12, "y": 0},
+          "fieldConfig": {"defaults": {"unit": "none"}, "overrides": []},
+          "options": {"reduceOptions": {"calcs": ["lastNotNull"]}, "colorMode": "value", "graphMode": "none"},
+          "targets": [
+            {"refId": "A", "datasource": {"type": "prometheus", "uid": "prometheus"},
+             "expr": "max_link_speed{source=~\"$source\"}", "legendFormat": "{{source}} {{hca}}"}
+          ]
+        },
+        {
+          "type": "stat",
+          "title": "Max PCIe Link Width (lanes)",
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "gridPos": {"h": 4, "w": 6, "x": 18, "y": 0},
+          "fieldConfig": {"defaults": {"unit": "none"}, "overrides": []},
+          "options": {"reduceOptions": {"calcs": ["lastNotNull"]}, "colorMode": "value", "graphMode": "none"},
+          "targets": [
+            {"refId": "A", "datasource": {"type": "prometheus", "uid": "prometheus"},
+             "expr": "max_link_width{source=~\"$source\"}", "legendFormat": "{{source}} {{hca}}"}
+          ]
+        },
+        {
+          "type": "timeseries",
+          "title": "Uplink RX throughput (p0/p1)",
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "gridPos": {"h": 8, "w": 12, "x": 0, "y": 4},
+          "fieldConfig": {"defaults": {"unit": "bps", "custom": {"drawStyle": "line", "fillOpacity": 10}}, "overrides": []},
+          "options": {"legend": {"displayMode": "table", "placement": "bottom", "calcs": ["mean", "max"]}, "tooltip": {"mode": "multi"}},
+          "targets": [
+            {"refId": "A", "datasource": {"type": "prometheus", "uid": "prometheus"},
+             "expr": "sum by(source)(rate({__name__=~\"p[01]_eth_rx_bytes\", source=~\"$source\"}[5m])) * 8",
+             "legendFormat": "{{source}}"}
+          ]
+        },
+        {
+          "type": "timeseries",
+          "title": "Uplink TX throughput (p0/p1)",
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "gridPos": {"h": 8, "w": 12, "x": 12, "y": 4},
+          "fieldConfig": {"defaults": {"unit": "bps", "custom": {"drawStyle": "line", "fillOpacity": 10}}, "overrides": []},
+          "options": {"legend": {"displayMode": "table", "placement": "bottom", "calcs": ["mean", "max"]}, "tooltip": {"mode": "multi"}},
+          "targets": [
+            {"refId": "A", "datasource": {"type": "prometheus", "uid": "prometheus"},
+             "expr": "sum by(source)(rate({__name__=~\"p[01]_eth_tx_bytes\", source=~\"$source\"}[5m])) * 8",
+             "legendFormat": "{{source}}"}
+          ]
+        },
+        {
+          "type": "timeseries",
+          "title": "Uplink packets/s (p0/p1 rx+tx)",
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "gridPos": {"h": 8, "w": 12, "x": 0, "y": 12},
+          "fieldConfig": {"defaults": {"unit": "pps", "custom": {"drawStyle": "line", "fillOpacity": 10}}, "overrides": []},
+          "options": {"legend": {"displayMode": "table", "placement": "bottom", "calcs": ["mean", "max"]}, "tooltip": {"mode": "multi"}},
+          "targets": [
+            {"refId": "A", "datasource": {"type": "prometheus", "uid": "prometheus"},
+             "expr": "sum by(source)(rate({__name__=~\"p[01]_eth_rx_packets\", source=~\"$source\"}[5m]))",
+             "legendFormat": "{{source}} rx"},
+            {"refId": "B", "datasource": {"type": "prometheus", "uid": "prometheus"},
+             "expr": "sum by(source)(rate({__name__=~\"p[01]_eth_tx_packets\", source=~\"$source\"}[5m]))",
+             "legendFormat": "{{source}} tx"}
+          ]
+        },
+        {
+          "type": "timeseries",
+          "title": "Uplink errors & drops/s (p0/p1)",
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "gridPos": {"h": 8, "w": 12, "x": 12, "y": 12},
+          "fieldConfig": {"defaults": {"unit": "cps", "custom": {"drawStyle": "line", "fillOpacity": 10}}, "overrides": []},
+          "options": {"legend": {"displayMode": "table", "placement": "bottom", "calcs": ["max"]}, "tooltip": {"mode": "multi"}},
+          "targets": [
+            {"refId": "A", "datasource": {"type": "prometheus", "uid": "prometheus"},
+             "expr": "sum by(source)(rate({__name__=~\"p[01]_eth_rx_errors\", source=~\"$source\"}[5m])) + sum by(source)(rate({__name__=~\"p[01]_eth_tx_errors\", source=~\"$source\"}[5m])) + sum by(source)(rate({__name__=~\"p[01]_eth_rx_dropped\", source=~\"$source\"}[5m])) + sum by(source)(rate({__name__=~\"p[01]_eth_tx_dropped\", source=~\"$source\"}[5m])) + sum by(source)(rate({__name__=~\"p[01]_eth_rx_crc_errors\", source=~\"$source\"}[5m]))",
+             "legendFormat": "{{source}}"}
+          ]
+        },
+        {
+          "type": "timeseries",
+          "title": "NIC channel poll/s",
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "gridPos": {"h": 8, "w": 12, "x": 0, "y": 20},
+          "fieldConfig": {"defaults": {"unit": "cps", "custom": {"drawStyle": "line", "fillOpacity": 10}}, "overrides": []},
+          "options": {"legend": {"displayMode": "table", "placement": "bottom", "calcs": ["mean", "max"]}, "tooltip": {"mode": "multi"}},
+          "targets": [
+            {"refId": "A", "datasource": {"type": "prometheus", "uid": "prometheus"},
+             "expr": "rate(ch_poll{source=~\"$source\"}[5m])",
+             "legendFormat": "{{source}} {{device_name}}"}
+          ]
+        },
+        {
+          "type": "timeseries",
+          "title": "NIC channel events/s",
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "gridPos": {"h": 8, "w": 12, "x": 12, "y": 20},
+          "fieldConfig": {"defaults": {"unit": "cps", "custom": {"drawStyle": "line", "fillOpacity": 10}}, "overrides": []},
+          "options": {"legend": {"displayMode": "table", "placement": "bottom", "calcs": ["mean", "max"]}, "tooltip": {"mode": "multi"}},
+          "targets": [
+            {"refId": "A", "datasource": {"type": "prometheus", "uid": "prometheus"},
+             "expr": "rate(ch_events{source=~\"$source\"}[5m])",
+             "legendFormat": "{{source}} {{device_name}}"}
+          ]
+        }
+      ]
+    }
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: doca-dpu-telemetry-dts
+  namespace: dpf-operator-system
+spec:
+  instanceSelector:
+    matchLabels:
+      dashboards: "dpf-grafana"
+  configMapRef:
+    name: dpf-dts-grafana-dashboard
+    key: doca-dpu-telemetry-dts.json

--- a/scripts/post-install.sh
+++ b/scripts/post-install.sh
@@ -411,6 +411,14 @@ function apply_observability() {
     log [INFO] "Applying Grafana manifests..."
     retry 5 30 apply_manifest "${OBSERVABILITY_DIR}/grafana" "true"
 
+    # Native OpenShift console dashboards (Observe -> Dashboards). These are
+    # ConfigMaps in openshift-config-managed labeled console.openshift.io/dashboard;
+    # they render against platform Thanos/UWM with no Grafana dependency.
+    if [ -d "${OBSERVABILITY_DIR}/console-dashboards" ]; then
+        log [INFO] "Applying OpenShift console dashboards..."
+        retry 5 30 apply_manifest "${OBSERVABILITY_DIR}/console-dashboards" "true"
+    fi
+
     log [INFO] "Observability manifest application completed successfully"
 }
 


### PR DESCRIPTION
DTS already exports ~3370 sysfs/ethtool DPU counters on :9189, scraped into OpenShift user-workload monitoring via the existing doca-telemetry-service ServiceMonitor. The DPF operator ships only framework/CR dashboards, so there was no view of DPU hardware telemetry.

Add a DOCA Telemetry Service (DTS) DPU hardware-telemetry dashboard in two forms:
  - a grafana-operator GrafanaDashboard that auto-loads into the existing dpf-grafana instance, and
  - a native OpenShift console dashboard (Observe -> Dashboards) that renders against platform Thanos/UWM with no Grafana dependency.

Wire a new manifests/observability/console-dashboards/ directory into apply_observability (guarded by a dir check, idempotent, runs last).

Panels are faceted by the DTS `source` label (DPU node) so they scale across a multi-DPU fleet, and use sum by(source)(rate(...)) to avoid the __name__-drop labelset collision when rx/tx counters are combined.

Purely observability-scoped: ConfigMaps plus one GrafanaDashboard CR; no change to DPU provisioning, networking, or install paths. Verified on an OCP/RHCOS host-trusted cluster with two DPUs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a native OpenShift Console dashboard for DOCA DPU Telemetry, making key telemetry graphs available directly in the console.
  * Added a Grafana dashboard for DOCA DPU Telemetry with panels for PCIe link stats, uplink throughput, packet rates, errors, and NIC channel activity.
  * Updated installation behavior to automatically apply console dashboard content when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->