### PR TITLE
Enable introspection on workers

### DIFF
--- a/manifests/worker-provisioning/baremetalhost.yaml
+++ b/manifests/worker-provisioning/baremetalhost.yaml
@@ -4,8 +4,6 @@ kind: BareMetalHost
 metadata:
   name: <WORKER_NAME>
   namespace: openshift-machine-api
-  annotations:
-    inspect.metal3.io: disabled
 spec:
   online: true
   bootMACAddress: <BOOT_MAC>


### PR DESCRIPTION
When BMO workers use customDeploy: install_coreos with inspection disabled, BMHs have no hardwareDetails so the Machine controller can't match Nodes to Machines. Machines get stuck in Provisioned phase, firing MachineWithNoRunningPhase and MachineWithoutValidNode alerts.

This is the proper solution to https://github.com/rh-ecosystem-edge/openshift-dpf/pull/210 , if this work we can close it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Re-enabled host inspection during bare metal provisioning, allowing hardware details to be detected automatically instead of being skipped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->