### PR TITLE
Add pre-install validation for HBN_OVN_NETWORK subnet

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ VM_SCRIPT := scripts/vm.sh
 UTILS_SCRIPT := scripts/utils.sh
 POST_INSTALL_SCRIPT := scripts/post-install.sh
 VERIFY_SCRIPT := scripts/verify.sh
+PREINSTALL_VALIDATE_SCRIPT := scripts/preinstall-validate.sh
 ENV_SCRIPT := scripts/env.sh
 
 # Sanity tests script:
@@ -36,7 +37,8 @@ WORKER_SCRIPT := scripts/worker.sh
         delete-dpf-hcp-provisioner-operator \
         verify-deployment verify-workers verify-dpu-nodes verify-dpudeployment \
         run-traffic-flow-tests tft-setup tft-cleanup tft-show-config tft-results aicli-list \
-        validate-env-files generate-env deploy-observability
+        validate-env-files generate-env deploy-observability \
+        validate-hbn-network
 
 all: 
 	@mkdir -p logs
@@ -61,7 +63,7 @@ aicli-list:
 delete-cluster:
 	@$(CLUSTER_SCRIPT) delete-cluster
 
-check-cluster:
+check-cluster: validate-hbn-network
 	@$(CLUSTER_SCRIPT) check-create-cluster
 
 create-cluster:
@@ -299,6 +301,9 @@ verify-dpu-nodes:
 verify-dpudeployment:
 	@$(VERIFY_SCRIPT) verify-dpudeployment
 
+validate-hbn-network:
+	@$(PREINSTALL_VALIDATE_SCRIPT) validate-hbn-network
+
 validate-env-files:
 	@$(ENV_SCRIPT) validate-env-files
 
@@ -361,6 +366,9 @@ help:
 	@echo "  deploy-csr-approver - Deploy CSR auto-approver CronJob for host cluster workers"
 	@echo "  delete-csr-approver - Remove CSR auto-approver from host cluster"
 	@echo "  delete-dpf-hcp-provisioner-operator - Remove DPF HCP Provisioner Operator and related resources"
+	@echo ""
+	@echo "Pre-install Validation:"
+	@echo "  validate-hbn-network  - Verify all IPs in HBN_OVN_NETWORK are free (nmap sweep)"
 	@echo ""
 	@echo "Verification:"
 	@echo "  verify-deployment     - Full verification: workers + DPU nodes + DPUDeployment"

--- a/scripts/preinstall-validate.sh
+++ b/scripts/preinstall-validate.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+# preinstall-validate.sh - Pre-installation network validation
+#
+# Validates that no IPs in the HBN_OVN_NETWORK subnet are already in use.
+# Uses nmap host discovery (-sn) to ping-sweep the subnet.
+
+set -e
+set -o pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/env.sh"
+source "${SCRIPT_DIR}/utils.sh"
+
+# -----------------------------------------------------------------------------
+# Validate HBN OVN Network IPs are free
+# -----------------------------------------------------------------------------
+validate_hbn_ovn_network() {
+    local network="${HBN_OVN_NETWORK}"
+
+    if [ -z "$network" ]; then
+        log "ERROR" "HBN_OVN_NETWORK is not set"
+        return 1
+    fi
+
+    log "INFO" "Validating that no IPs are in use in HBN_OVN_NETWORK=${network} ..."
+
+    if ! command -v nmap &>/dev/null; then
+        log "ERROR" "nmap is required but not installed"
+        return 1
+    fi
+
+    local nmap_output
+    if ! nmap_output=$(sudo nmap -sn "$network" -oG - 2>&1); then
+        log "ERROR" "nmap scan failed for ${network}: ${nmap_output}"
+        return 1
+    fi
+
+    local alive_hosts
+    alive_hosts=$(awk '/Status: Up/ {print $2}' <<< "$nmap_output")
+
+    if [ -z "$alive_hosts" ]; then
+        log "INFO" "All IPs in ${network} are free"
+        return 0
+    fi
+
+    local count
+    count=$(echo "$alive_hosts" | wc -l | tr -d '[:space:]')
+
+    log "ERROR" "Found ${count} host(s) responding in ${network}:"
+    while IFS= read -r ip; do
+        log "ERROR" "  ${ip} is in use"
+    done <<< "$alive_hosts"
+
+    log "ERROR" "HBN_OVN_NETWORK subnet is not free — resolve IP conflicts before deploying DPF"
+    return 1
+}
+
+# -----------------------------------------------------------------------------
+# Command Dispatcher
+# -----------------------------------------------------------------------------
+case "${1:-}" in
+    validate-hbn-network) validate_hbn_ovn_network ;;
+    *)
+        echo "Usage: $0 {validate-hbn-network}"
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
## Summary
- Adds `nmap -sn` sweep of `HBN_OVN_NETWORK` CIDR to detect IP conflicts before installation
- New `scripts/preinstall-validate.sh` script and `make validate-hbn-network` target
- Wired into `make all` flow right after `verify-files` to fail fast before cluster creation

## Test plan
- [ ] Run `make validate-hbn-network` against a subnet with known active hosts — should fail listing conflicting IPs
- [ ] Run against a free subnet — should pass
- [ ] Run `make all` and verify validation runs early in the flow


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a pre-installation network validation step to detect IP address conflicts before deployment.
  * Introduced a new make target to run this validation as part of the normal setup flow.
  * Updated the build help output to document the new validation target.
  * The validation fails when the configured network subnet already has responsive hosts, preventing unsafe installation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->