### PR TITLE
Enable multinetworking on host cluster

### DIFF
--- a/scripts/dpf.sh
+++ b/scripts/dpf.sh
@@ -509,6 +509,10 @@ function apply_dpf() {
     log "INFO" "Enabling IP forwarding for OVN Kubernetes..."
     oc patch network.operator.openshift.io cluster --type=merge -p \
     '{"spec":{"defaultNetwork":{ "ovnKubernetesConfig":{"gatewayConfig":{"ipForwarding":"Global"}}}}}'
+
+    log "INFO" "Enabling MultiNetworkPolicy on the cluster network operator..."
+    oc patch network.operator.openshift.io cluster --type=merge -p \
+    '{"spec":{"useMultiNetworkPolicy":true}}'
     
     deploy_nfd
     


### PR DESCRIPTION
This is a prerequisite to enable multiNetwork on the OVNK DPU side.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled MultiNetworkPolicy support during deployment configuration, allowing multiple network policies to work together more consistently.
  * Added an explicit deployment step for turning on this networking capability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->