### PR TITLE
Upstream e2e testing integration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,8 @@ WORKER_SCRIPT := scripts/worker.sh
         delete-dpf-hcp-provisioner-operator \
         verify-deployment verify-workers verify-dpu-nodes verify-dpudeployment \
         run-traffic-flow-tests tft-setup tft-cleanup tft-show-config tft-results aicli-list \
-        validate-env-files generate-env deploy-observability
+        validate-env-files generate-env deploy-observability \
+        test-e2e test-e2e-setup test-e2e-clean
 
 all: 
 	@mkdir -p logs
@@ -227,6 +228,18 @@ run-dpf-sanity:
 	@chmod +x $(SANITY_CHECKS_SCRIPT)
 	@$(SANITY_CHECKS_SCRIPT)
 
+# E2E Tests (upstream NVIDIA DPF)
+E2E_SCRIPT := scripts/e2e.sh
+
+test-e2e-setup:
+	@$(E2E_SCRIPT) setup
+
+test-e2e: test-e2e-setup
+	@$(E2E_SCRIPT) run
+
+test-e2e-clean:
+	@$(E2E_SCRIPT) clean
+
 # Traffic Flow Tests
 run-traffic-flow-tests:
 	@echo "================================================================================"
@@ -367,6 +380,11 @@ help:
 	@echo "  verify-workers        - Wait for worker nodes to be Ready in host cluster"
 	@echo "  verify-dpu-nodes      - Wait for DPU nodes to be Ready in DPUCluster"
 	@echo "  verify-dpudeployment  - Wait for DPUDeployment to be Ready"
+	@echo ""
+	@echo "E2E Tests (upstream NVIDIA DPF):"
+	@echo "  test-e2e               - Setup and run upstream e2e tests (default: leader election)"
+	@echo "  test-e2e-setup         - Clone upstream repo and apply patch only"
+	@echo "  test-e2e-clean         - Remove cloned upstream repo"
 	@echo ""
 	@echo "Traffic Flow Tests:"
 	@echo "  run-traffic-flow-tests - Run kubernetes-traffic-flow-tests for network validation"

--- a/ci/patches/e2e-skip-setup.patch
+++ b/ci/patches/e2e-skip-setup.patch
@@ -1,13 +1,6 @@
 --- a/test/e2e/e2e_suite_test.go
 +++ b/test/e2e/e2e_suite_test.go
-@@ -1,5 +1,6 @@
- /*
- Copyright 2024 NVIDIA
-+Copyright 2026 Red Hat
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
-@@ -253,6 +254,12 @@ var _ = BeforeSuite(func() {
+@@ -253,6 +253,12 @@ var _ = BeforeSuite(func() {
 
  	cleanupTracker = cleanup.NewTracker(utils.CleanupWithLabelAndWait, cleanupFlags, ctx, testClient, resourcesToDelete)
 

--- a/ci/patches/e2e-skip-setup.patch
+++ b/ci/patches/e2e-skip-setup.patch
@@ -1,0 +1,53 @@
+--- a/test/e2e/e2e_suite_test.go
++++ b/test/e2e/e2e_suite_test.go
+@@ -1,5 +1,6 @@
+ /*
+ Copyright 2024 NVIDIA
++Copyright 2026 Red Hat
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+@@ -253,6 +254,12 @@ var _ = BeforeSuite(func() {
+
+ 	cleanupTracker = cleanup.NewTracker(utils.CleanupWithLabelAndWait, cleanupFlags, ctx, testClient, resourcesToDelete)
+
++	// openshift-dpf patch: skip resource creation for pre-existing deployments.
++	if os.Getenv("DPF_SKIP_SETUP") != "" {
++		By("DPF_SKIP_SETUP is set — running against pre-existing deployment, skipping setup")
++		return
++	}
++
+ 	// Upgrade validation tests skip cleanup to preserve resources from previous test run.
+ 	// isUpgradeValidationPhase matches the active label filter against every label
+ 	// registered by validationPhase, so no per-phase update is needed here when a new
+@@ -378,7 +385,9 @@ var _ = BeforeSuite(func() {
+
+ var _ = ReportBeforeEach(func(spec SpecReport) {
+ 	// Detect entering scopes and perform "before" cleanup
+-	cleanupTracker.HandleScopeLifecycle(&spec, cleanup.GinkgoHook.BeforeEach)
++	if cleanupTracker != nil {
++		cleanupTracker.HandleScopeLifecycle(&spec, cleanup.GinkgoHook.BeforeEach)
++	}
+ })
+
+ // reportAfterEach collects diagnostics when a test fails
+@@ -411,7 +420,9 @@ var _ = ReportAfterEach(func(spec SpecReport) {
+ 	reportAfterEach(spec)
+
+ 	// Handle scope lifecycle and cleanup
+-	cleanupTracker.HandleScopeLifecycle(&spec, cleanup.GinkgoHook.AfterEach)
++	if cleanupTracker != nil {
++		cleanupTracker.HandleScopeLifecycle(&spec, cleanup.GinkgoHook.AfterEach)
++	}
+ })
+
+ var _ = AfterSuite(func() {
+@@ -441,5 +452,7 @@ var _ = AfterSuite(func() {
+ 	}
+
+ 	By("Performing final suite cleanup")
+-	cleanupTracker.HandleScopeLifecycle(nil, cleanup.GinkgoHook.AfterSuite)
++	if cleanupTracker != nil {
++		cleanupTracker.HandleScopeLifecycle(nil, cleanup.GinkgoHook.AfterSuite)
++	}
+ })

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -1,0 +1,207 @@
+#!/bin/bash
+# e2e.sh - Run upstream NVIDIA DPF e2e tests against a pre-existing deployment
+#
+# This script:
+# 1. Clones the NVIDIA doca-platform repository at a pinned release tag
+# 2. Applies a patch to skip BeforeSuite resource creation (DPF_SKIP_SETUP)
+# 3. Runs selected e2e tests via Ginkgo label/focus filtering
+#
+# Repository: https://github.com/NVIDIA/doca-platform
+
+set -e
+set -o pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+if [ -z "${MAKELEVEL:-}" ]; then
+    source "${SCRIPT_DIR}/env.sh"
+fi
+source "${SCRIPT_DIR}/utils.sh"
+
+# -----------------------------------------------------------------------------
+# Configuration
+# -----------------------------------------------------------------------------
+
+DPF_UPSTREAM_REPO="${DPF_UPSTREAM_REPO:-https://github.com/NVIDIA/doca-platform.git}"
+DPF_UPSTREAM_TAG="${DPF_UPSTREAM_TAG:-public-main}"
+DPF_UPSTREAM_DIR="${DPF_UPSTREAM_DIR:-${PROJECT_DIR}/repos/doca-platform}"
+DPF_E2E_PATCH="${DPF_E2E_PATCH:-${PROJECT_DIR}/ci/patches/e2e-skip-setup.patch}"
+
+E2E_KUBECONFIG="${E2E_KUBECONFIG:-${KUBECONFIG:-${HOME}/.kube/config}}"
+E2E_FOCUS="${E2E_FOCUS:-provisioning-controller leader pod is deleted}"
+E2E_LABEL_FILTER="${E2E_LABEL_FILTER:-DPFSystem}"
+E2E_TIMEOUT="${E2E_TIMEOUT:-10m}"
+E2E_CONFIG="${E2E_CONFIG:-./config-quick.yaml}"
+
+# Go 1.21+ supports automatic toolchain downloading via GOTOOLCHAIN=auto
+GO_MIN_VERSION="1.21"
+
+# -----------------------------------------------------------------------------
+# Go Version Check
+# -----------------------------------------------------------------------------
+check_go_version() {
+    if ! command -v go &>/dev/null; then
+        log "ERROR" "Go is not installed (>= ${GO_MIN_VERSION} required for toolchain auto-download)"
+        log "INFO" "Install via: scripts/golang-installation.sh or https://go.dev/dl/"
+        return 1
+    fi
+
+    local go_version
+    go_version=$(go version | grep -oP 'go\K[0-9]+\.[0-9]+')
+    if ! printf '%s\n%s\n' "${GO_MIN_VERSION}" "${go_version}" | sort -V -C; then
+        log "ERROR" "Go ${go_version} found, but >= ${GO_MIN_VERSION} required for toolchain auto-download"
+        log "INFO" "Install via: scripts/golang-installation.sh or https://go.dev/dl/"
+        return 1
+    fi
+
+    export GOTOOLCHAIN=auto
+    log "INFO" "Go version: $(go version) (GOTOOLCHAIN=auto for upstream compatibility)"
+}
+
+# -----------------------------------------------------------------------------
+# Clone/Update Repository
+# -----------------------------------------------------------------------------
+setup_repo() {
+    log "INFO" "Setting up doca-platform repository (tag: ${DPF_UPSTREAM_TAG})..."
+
+    if [[ -d "${DPF_UPSTREAM_DIR}/.git" ]]; then
+        log "INFO" "Repository already cloned at ${DPF_UPSTREAM_DIR}"
+    else
+        log "INFO" "Shallow-cloning from ${DPF_UPSTREAM_REPO} (ref: ${DPF_UPSTREAM_TAG})..."
+        git clone --depth 1 --branch "${DPF_UPSTREAM_TAG}" "${DPF_UPSTREAM_REPO}" "${DPF_UPSTREAM_DIR}"
+    fi
+
+    apply_patch
+    download_modules
+    log "INFO" "Setup complete"
+}
+
+# -----------------------------------------------------------------------------
+# Apply Patch
+# -----------------------------------------------------------------------------
+apply_patch() {
+    log "INFO" "Applying e2e skip-setup patch..."
+
+    if ! [[ -f "${DPF_E2E_PATCH}" ]]; then
+        log "ERROR" "Patch file not found: ${DPF_E2E_PATCH}"
+        return 1
+    fi
+
+    pushd "${DPF_UPSTREAM_DIR}" > /dev/null
+    if git diff --quiet test/e2e/e2e_suite_test.go 2>/dev/null; then
+        git apply "${DPF_E2E_PATCH}"
+        log "INFO" "Patch applied successfully"
+    else
+        log "INFO" "Patch already applied (file has local changes)"
+    fi
+    popd > /dev/null
+}
+
+# -----------------------------------------------------------------------------
+# Download Go Modules
+# -----------------------------------------------------------------------------
+download_modules() {
+    log "INFO" "Downloading Go modules..."
+    pushd "${DPF_UPSTREAM_DIR}" > /dev/null
+    go mod download
+    popd > /dev/null
+    log "INFO" "Go modules ready"
+}
+
+# -----------------------------------------------------------------------------
+# Run E2E Tests
+# -----------------------------------------------------------------------------
+run_tests() {
+    check_go_version
+
+    if ! [[ -d "${DPF_UPSTREAM_DIR}/.git" ]]; then
+        log "ERROR" "Repository not found at ${DPF_UPSTREAM_DIR}. Run 'setup' first."
+        return 1
+    fi
+
+    # Resolve kubeconfig to absolute path since go test runs from the cloned repo dir
+    E2E_KUBECONFIG="$(realpath "${E2E_KUBECONFIG}")"
+
+    log "INFO" "Running e2e tests..."
+    log "INFO" "  Kubeconfig:    ${E2E_KUBECONFIG}"
+    log "INFO" "  Focus:         ${E2E_FOCUS}"
+    log "INFO" "  Label filter:  ${E2E_LABEL_FILTER}"
+    log "INFO" "  Config:        ${E2E_CONFIG}"
+    log "INFO" "  Timeout:       ${E2E_TIMEOUT}"
+
+    pushd "${DPF_UPSTREAM_DIR}" > /dev/null
+
+    DPF_SKIP_SETUP=true \
+    DPF_E2E_COLLECT_RESOURCES=false \
+    HELM_REGISTRY=unused \
+    DOCKER_IO_REGISTRY=unused \
+    TAG=unused \
+    NETUTILS_IMAGE=unused \
+    go test -v -count=1 -timeout "${E2E_TIMEOUT}" ./test/e2e/ \
+        -ginkgo.v \
+        -ginkgo.fail-fast \
+        -ginkgo.label-filter="${E2E_LABEL_FILTER}" \
+        -ginkgo.focus="${E2E_FOCUS}" \
+        -e2e.testKubeconfig="${E2E_KUBECONFIG}" \
+        -e2e.config="${E2E_CONFIG}" \
+        -e2e.skip-cleanup.suite-after=true \
+        "$@"
+
+    popd > /dev/null
+    log "INFO" "E2E tests complete"
+}
+
+# -----------------------------------------------------------------------------
+# Cleanup
+# -----------------------------------------------------------------------------
+clean_repo() {
+    if [[ -d "${DPF_UPSTREAM_DIR}" ]]; then
+        log "INFO" "Removing ${DPF_UPSTREAM_DIR}..."
+        rm -rf "${DPF_UPSTREAM_DIR}"
+        log "INFO" "Cleanup complete"
+    else
+        log "INFO" "Nothing to clean"
+    fi
+}
+
+# -----------------------------------------------------------------------------
+# Command Dispatcher
+# -----------------------------------------------------------------------------
+case "${1:-}" in
+    setup)
+        check_go_version
+        setup_repo
+        ;;
+    run)
+        shift
+        run_tests "$@"
+        ;;
+    run-full|"")
+        check_go_version
+        setup_repo
+        run_tests
+        ;;
+    clean)
+        clean_repo
+        ;;
+    *)
+        echo "Usage: $0 {setup|run|run-full|clean}"
+        echo ""
+        echo "Commands:"
+        echo "  setup      - Clone upstream repo and apply patch"
+        echo "  run        - Run e2e tests (assumes setup is complete)"
+        echo "  run-full   - Full workflow: setup + run (default)"
+        echo "  clean      - Remove cloned repository"
+        echo ""
+        echo "Environment Variables:"
+        echo "  DPF_UPSTREAM_TAG    - Upstream git ref (default: public-main)"
+        echo "  E2E_KUBECONFIG      - Path to kubeconfig (default: KUBECONFIG or ~/.kube/config)"
+        echo "  E2E_FOCUS           - Ginkgo focus filter (default: 'provisioning-controller leader pod is deleted')"
+        echo "  E2E_LABEL_FILTER    - Ginkgo label filter (default: 'DPFSystem')"
+        echo "  E2E_TIMEOUT         - Test timeout (default: 10m)"
+        echo "  E2E_CONFIG          - Upstream config file (default: ./config-quick.yaml)"
+        echo ""
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
## Summary

Integrates upstream NVIDIA DPF e2e tests ([`NVIDIA/doca-platform/test/e2e`](https://github.com/NVIDIA/doca-platform/tree/public-main/test/e2e)) into this repo, allowing us to run the actual upstream Ginkgo test suite against a pre-existing DPF deployment without reimplementing any tests.

- Clones upstream repo at a pinned git ref, applies a small patch to skip `BeforeSuite` resource creation, and runs selected tests via Ginkgo label/focus filtering
- New wrapper script `scripts/e2e.sh` (setup/run/clean subcommands) and Makefile targets (`test-e2e`, `test-e2e-setup`, `test-e2e-clean`)
- Verified with the leader election failover test (`provisioning-controller`) — passed in ~36s against a live cluster

## Approaches considered

Three approaches were evaluated for integrating upstream e2e tests:

### Option A: Patch file (chosen)

Clone upstream at a pinned ref, apply a `git apply` patch to `e2e_suite_test.go` that adds a `DPF_SKIP_SETUP` env var guard to skip `BeforeSuite` resource creation, and run via `go test` with Ginkgo focus/label filtering.

| Pros | Cons |
|------|------|
| Runs the actual upstream test code — no reimplementation | Patch may need rebasing when upstream changes `e2e_suite_test.go` |
| Minimal diff (~30 lines): early return in `BeforeSuite` + nil guards for `cleanupTracker` | Tied to a specific upstream ref (though easy to bump) |
| Adding new tests = changing `E2E_FOCUS` / `E2E_LABEL_FILTER` env vars, no code changes | |
| Follows existing repo conventions (`scripts/`, `repos/`, Makefile targets) | |
| Upstream's `AfterSuite` skip flag (`-e2e.skip-cleanup.suite-after=true`) already exists — no patch needed there | |

> [!NOTE]
> The patch could be eliminated entirely if upstream added a native `--skip-setup` flag (analogous to the existing -`e2e.skip-cleanup.suite-after`), allowing BeforeSuite to be skipped without patching, **worth proposing upstream**.

### Option B: Fork/vendor the upstream test directory

Copy or git-subtree the entire `test/e2e/` directory into this repo, modify `BeforeSuite` directly, and maintain it as a vendored copy.

| Pros | Cons |
|------|------|
| Full control over test code | Must manually sync 40+ test files on every upstream update |
| No patch to maintain | Drift risk — hard to tell what's upstream vs. local |
| Can freely restructure tests | Large amount of Go code in a repo that is otherwise shell/YAML |



### Option C: Go module import (best approach, needs upstream changes)

Import the upstream test package as a Go module dependency (`go get github.com/nvidia/doca-platform/test/e2e`) and call exported test functions from a thin local test file.

| Pros | Cons |
|------|------|
| Clean separation — upstream is a dependency | Key types and helpers (`leaderElectionTarget`, `scaleControllerReplicas`, etc.) are ercase), blocking direct use |
| Automatic updates via `go get -u` | Adds a full Go module to a repo that is otherwise shell/YAML |
| No patch maintenance | |
| No drift risk — always consuming upstream code as-is | |

> [!NOTE]
> This option is currently blocked but could become the preferred approach if upstream exports the relevant types and helpers (e.g. `LeaderElectiplicas`). This would be a small non-breaking change: **worth proposing upstream**. If accepted, we could drop the patch entirely and consume the test library as a regular Go dependency.

## How it works

1. `make test-e2e-setup` shallow-clones `NVIDIA/doca-platform` at `DPF_UPSTREAM_TAG` (default: `public-main`) into `repos/doca-platform/` and applies `ci/patches/e2e-skip-setup.patch`
2. `make test-e2e` runs `go test ./test/e2e/` with:
   - `DPF_SKIP_SETUP=true` — triggers the patched early return in `BeforeSuite`
   - `DPF_E2E_COLLECT_RESOURCES=false` — disables resource collection on failure
   - `-e2e.skip-cleanup.suite-after=true` — prevents `AfterSuite` from deleting `DPFOperatorConfig`
   - `-ginkgo.focus` / `-ginkgo.label-filter` — selects which tests to run
   - Dummy values for `HELM_REGISTRY`, `TAG`, `NETUTILS_IMAGE`, `DOCKER_IO_REGISTRY` (required by `init()` but unused when setup is skipped)
3. `make test-e2e-clean` removes the cloned repo

### Configuration

All settings are overridable via environment variables:

| Variable | Default | Description |
|----------|---------|-------------|
| `DPF_UPSTREAM_TAG` | `public-main` | Upstream git ref to clone |
| `E2E_FOCUS` | `provisioning-controller leader pod is deleted` | Ginkgo focus regex |
| `E2E_LABEL_FILTER` | `DPFSystem` | Ginkgo label filter |
| `E2E_TIMEOUT` | `10m` | Test timeout |
| `E2E_KUBECONFIG` | `$KUBECONFIG` | Path to kubeconfig |

## Known limitations

- The `dpuservice-controller`, `kamaji-cluster-manager`, and `static-cluster-manager` leader election tests fail because these components are not exposed in `DPFOperatorConfig.ComponentConfigs()` for replica scaling — upstream gap, not a patch issue
- Currently pinned to `public-main` (HEAD) since the leader election test only exists there, not in release tags (e.g. `v26.4.0`). Once upstream cuts a release containing it, we should pin to a release tag for stability
- The patch needs to be verified/rebased when bumping `DPF_UPSTREAM_TAG`

## Test plan

- [x] `make test-e2e` runs the provisioning-controller leader election failover test and passes (~36s)
- [ ] Verify `make test-e2e-clean` removes the cloned repo
- [ ] Test with a different `E2E_FOCUS` to run additional upstream tests
- [ ] Pin to a release tag once upstream includes the leader election test

Assisted-by: Claude 🤖