### PR TITLE
Set host_network_namespace to openshift-host-network

### DIFF
--- a/manifests/helm-charts-values/ovn-values-with-injector.yaml
+++ b/manifests/helm-charts-values/ovn-values-with-injector.yaml
@@ -40,6 +40,7 @@ k8sAPIServer: https://<TARGETCLUSTER_API_SERVER_HOST>:<TARGETCLUSTER_API_SERVER_
 podNetwork: <POD_CIDR>/24
 serviceNetwork: <SERVICE_CIDR>
 gatewayOpts: --gateway-interface=<DPU_P0>
+hostNetworkNamespace: openshift-host-network
 
 # DPU manifests configuration (for DPUService deployment)
 dpuManifests:

--- a/manifests/helm-charts-values/ovn-values.yaml
+++ b/manifests/helm-charts-values/ovn-values.yaml
@@ -40,6 +40,7 @@ k8sAPIServer: https://<TARGETCLUSTER_API_SERVER_HOST>:<TARGETCLUSTER_API_SERVER_
 podNetwork: <POD_CIDR>/24
 serviceNetwork: <SERVICE_CIDR>
 gatewayOpts: --gateway-interface=<DPU_P0>
+hostNetworkNamespace: openshift-host-network
 
 # DPU manifests configuration (for DPUService deployment)
 dpuManifests:


### PR DESCRIPTION
https://github.com/Mellanox/ovn-kubernetes-dpf/pull/46 and https://github.com/Mellanox/ovn-kubernetes-dpf/pull/47 have merged and have been backported to [v26.4-ocp-beta3](https://github.com/Mellanox/ovn-kubernetes-dpf/tree/refs/tags/v26.4-ocp-beta3).

Fixes: https://partners.nvidia.com/Bug/ViewBug/6389971

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new host network namespace setting for OVN-related deployment values, using `openshift-host-network`.
  * Applied the same configuration to the injector-enabled variant of the chart values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->