### PR TITLE
Enable introspection on workers (2)

### DIFF
--- a/manifests/worker-provisioning/baremetalhost-dpu.yaml
+++ b/manifests/worker-provisioning/baremetalhost-dpu.yaml
@@ -6,8 +6,6 @@ metadata:
   namespace: openshift-machine-api
   labels:
     dpu-capable: "true"
-  annotations:
-    inspect.metal3.io: disabled
 spec:
   online: false
   bootMACAddress: <BOOT_MAC>


### PR DESCRIPTION
Continuation of https://github.com/rh-ecosystem-edge/openshift-dpf/pull/213
 
PR #213 only edited _manifests/worker-provisioning/baremetalhost.yaml_, but non-SNO DPU-capable workers are provisioned from a different template, _manifests/worker-provisioning/baremetalhost-dpu.yaml_ .

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated bare metal provisioning settings so hardware inspection is no longer disabled by default, allowing normal inspection to run during host setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->