### PR TITLE
Update BFB_URL RHCOS 10.2 build with GRUB

### DIFF
--- a/ci/env.defaults
+++ b/ci/env.defaults
@@ -113,7 +113,7 @@ WORKER_STATIC_NET_FILE=${WORKER_STATIC_NET_FILE:-${GENERATED_DIR}/worker_static_
 STORAGE_TYPE=${STORAGE_TYPE:-lvm}
 SKIP_DEPLOY_STORAGE=${SKIP_DEPLOY_STORAGE:-false}
 BFB_STORAGE_CLASS=${BFB_STORAGE_CLASS:-lvms-vg1}
-BFB_URL=${BFB_URL:-}
+BFB_URL=${BFB_URL:-https://bfb.okoyl.xyz/generic-rhcos-bfb/rhcos-grub_10.2.20260521-0_2026-07-08.bfb}
 
 # Bluefield image layer
 BLUEFIELD_OCP_IMAGE=${BLUEFIELD_OCP_IMAGE:-quay.io/eelgaev/bluefield-ocp:4.22.0_3.4.0-rh10.2}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default build artifact used when no custom value is provided, so environments now fall back to a specific RHCOS BFB image instead of leaving it unset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->