### PR TITLE
[release-4.22] NO-ISSUE: Align dpf-hcp-provisioner operator defaults with 4.22

### DIFF
--- a/ci/env.defaults
+++ b/ci/env.defaults
@@ -148,12 +148,12 @@ SANITY_TESTS_PING_COUNT=${SANITY_TESTS_PING_COUNT:-20}
 SANITY_TESTS_PING_HBN_TO_HBN_PODS=${SANITY_TESTS_PING_HBN_TO_HBN_PODS:-false}
 
 # DPF HCP Provisioner Operator Configuration
-DPF_HCP_PROVISIONER_OPERATOR_CHART_URL=${DPF_HCP_PROVISIONER_OPERATOR_CHART_URL:-oci://quay.io/redhat-user-workloads/dpu-kit-for-nvidia-operator-tenant/chart}
+DPF_HCP_PROVISIONER_OPERATOR_CHART_URL=${DPF_HCP_PROVISIONER_OPERATOR_CHART_URL:-oci://quay.io/redhat-user-workloads/dpu-kit-for-nvidia-operator-tenant/chart-4-22}
 DPF_HCP_PROVISIONER_OPERATOR_NAMESPACE=${DPF_HCP_PROVISIONER_OPERATOR_NAMESPACE:-dpf-hcp-provisioner-system}
 # When empty, helm pull/upgrade omits --version and fetches the highest available semver from the OCI registry.
 # Helm does not support "latest" as a chart version (not valid semver).
 DPF_HCP_PROVISIONER_OPERATOR_VERSION=${DPF_HCP_PROVISIONER_OPERATOR_VERSION:-}
-DPF_HCP_PROVISIONER_OPERATOR_IMAGE_REPO=${DPF_HCP_PROVISIONER_OPERATOR_IMAGE_REPO:-quay.io/redhat-user-workloads/dpu-kit-for-nvidia-operator-tenant/dpf-hcp-provisioner-rhel10-operator}
+DPF_HCP_PROVISIONER_OPERATOR_IMAGE_REPO=${DPF_HCP_PROVISIONER_OPERATOR_IMAGE_REPO:-quay.io/redhat-user-workloads/dpu-kit-for-nvidia-operator-tenant/dpf-hcp-provisioner-rhel10-operator-4-22}
 DPF_HCP_PROVISIONER_OPERATOR_IMAGE_TAG=${DPF_HCP_PROVISIONER_OPERATOR_IMAGE_TAG:-latest}
 DPFHCPPROVISIONER_PULL_SECRET_NAME=${DPFHCPPROVISIONER_PULL_SECRET_NAME:-my-pull-secret}
 DPFHCPPROVISIONER_SSH_SECRET_NAME=${DPFHCPPROVISIONER_SSH_SECRET_NAME:-my-ssh-key}


### PR DESCRIPTION
Align dpf-hcp-provisioner operator defaults (image and chart) with 4.22

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default deployment references to use versioned chart and container image values, aligning installs with the 4.22 release line.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->