### PR TITLE
[release-4.22] NO-ISSUE: Reduce OWNERS list in release-4.22

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,17 +1,11 @@
 approvers:
-- szigmon
 - tsorya
-- wabouhamad
-- SharonBX
 - eelgaev
 - linoyaslan
 - josecastillolema
 options: {}
 reviewers:
-- szigmon
 - tsorya
-- wabouhamad
-- SharonBX
 - eelgaev
 - linoyaslan
 - josecastillolema


### PR DESCRIPTION
As part of 4.22 feature-freeze, we reduce the OWNERS list