### PR TITLE
Set hostNetworkNamespace to openshift-host-network

### DIFF
--- a/manifests/post-installation/ovn-configuration.yaml
+++ b/manifests/post-installation/ovn-configuration.yaml
@@ -15,6 +15,7 @@ spec:
         k8sAPIServer: https://<HOST_CLUSTER_API>:6443
         podNetwork: 10.128.0.0/14/23
         serviceNetwork: 172.30.0.0/16
+        hostNetworkNamespace: "openshift-host-network"
         mtu: <NODES_MTU>
         dpuManifests:
           ovnMultiNetworkEnable: "<OVN_MULTI_NETWORK_ENABLE_VALUE>"


### PR DESCRIPTION
Continuation of https://github.com/rh-ecosystem-edge/openshift-dpf/pull/222 to fix: https://partners.nvidia.com/Bug/ViewBug/6389971

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated OVN DPU service networking configuration to use the OpenShift host network namespace, improving deployment compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->