### PR TITLE
Revert "Enable multinetworking on host cluster"

### DIFF
--- a/scripts/dpf.sh
+++ b/scripts/dpf.sh
@@ -542,10 +542,6 @@ function apply_dpf() {
     log "INFO" "Enabling IP forwarding for OVN Kubernetes..."
     oc patch network.operator.openshift.io cluster --type=merge -p \
     '{"spec":{"defaultNetwork":{ "ovnKubernetesConfig":{"gatewayConfig":{"ipForwarding":"Global"}}}}}'
-
-    log "INFO" "Enabling MultiNetworkPolicy on the cluster network operator..."
-    oc patch network.operator.openshift.io cluster --type=merge -p \
-    '{"spec":{"useMultiNetworkPolicy":true}}'
     
     deploy_nfd
     


### PR DESCRIPTION
Reverts rh-ecosystem-edge/openshift-dpf#216

Let's revert this from now until we have time to explore the multi networking functionality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the DPF deployment configuration to enable global OVN Kubernetes IP forwarding.
  * Improved network behavior for subsequent deployment and operator installation steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->