### PR TITLE
Update Bluefield OCP image version

### DIFF
--- a/ci/env.defaults
+++ b/ci/env.defaults
@@ -116,7 +116,7 @@ BFB_STORAGE_CLASS=${BFB_STORAGE_CLASS:-lvms-vg1}
 BFB_URL=${BFB_URL:-https://bfb.okoyl.xyz/generic-rhcos-bfb/rhcos-10.2.20260713-0-nvidiabluefield.aarch64.bfb}
 
 # Bluefield image layer
-BLUEFIELD_OCP_IMAGE=${BLUEFIELD_OCP_IMAGE:-quay.io/eelgaev/bluefield-ocp:4.22.0_3.4.0-rh10.2}
+BLUEFIELD_OCP_IMAGE=${BLUEFIELD_OCP_IMAGE:-quay.io/edge-infrastructure/bluefield-ocp:4.22.2}
 
 # Kubeconfig
 KUBECONFIG=${KUBECONFIG:-./kubeconfig}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default BlueField OpenShift image to version 4.22.2.
  * Switched to the current image source for improved compatibility and maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->