### PR TITLE
Remove OVN configuration values already set by provisioner

### DIFF
--- a/manifests/post-installation/ovn-configuration.yaml
+++ b/manifests/post-installation/ovn-configuration.yaml
@@ -11,14 +11,12 @@ spec:
         global:
           enableOvnKubeIdentity: false
           imagePullSecretName: "dpf-pull-secret"
-          <OVN_CONFIGURATION_FEATURES>
         k8sAPIServer: https://<HOST_CLUSTER_API>:6443
         podNetwork: 10.128.0.0/14/23
         serviceNetwork: 172.30.0.0/16
         hostNetworkNamespace: "openshift-host-network"
         mtu: <NODES_MTU>
         dpuManifests:
-          ovnMultiNetworkEnable: "<OVN_MULTI_NETWORK_ENABLE_VALUE>"
           kubernetesSecretName: "ovn-dpu"
           vtepCIDR: "<HBN_OVN_NETWORK>"
           hostCIDR: "<DPU_HOST_CIDR>"

--- a/scripts/post-install.sh
+++ b/scripts/post-install.sh
@@ -71,24 +71,6 @@ function update_hbn_ovn_manifests() {
         "<HBN_OVN_NETWORK>" \
         "${HBN_OVN_NETWORK}"
 
-    # OVN feature flags are only enabled on OCP >= 4.22.2
-    local ovn_configuration_features=""
-    local ovn_multi_network_enable_value="false"
-    if ocp_version_gte "${OPENSHIFT_VERSION}" "4.22.2"; then
-        ovn_configuration_features="enableEgressIP: \"true\"
-          enableEgressFirewall: \"true\"
-          enableEgressQoS: \"true\"
-          enableEgressService: \"true\"
-          enableMultiNetwork: \"false\"
-          enableMultiNetworkPolicy: \"true\"
-          enableAdminNetworkPolicy: \"true\"
-          enableNetworkSegmentation: \"true\""
-        ovn_multi_network_enable_value="true"
-        log "INFO" "OCP ${OPENSHIFT_VERSION} >= 4.22.2: enabling OVN feature flags"
-    else
-        log "INFO" "OCP ${OPENSHIFT_VERSION} < 4.22.2: skipping OVN feature flags"
-    fi
-
     # Update ovn-configuration.yaml for DPUDeployment
     if [ -f "${POST_INSTALL_DIR}/ovn-configuration.yaml" ]; then
         local ovn_mtu=""
@@ -106,9 +88,7 @@ function update_hbn_ovn_manifests() {
             "<HBN_OVN_NETWORK>" "${HBN_OVN_NETWORK}" \
             "<HOST_CLUSTER_API>" "${HOST_CLUSTER_API}" \
             "<DPU_HOST_CIDR>" "${DPU_HOST_CIDR}" \
-            "<NODES_MTU>" "${ovn_mtu}" \
-            "<OVN_CONFIGURATION_FEATURES>" "${ovn_configuration_features}" \
-            "<OVN_MULTI_NETWORK_ENABLE_VALUE>" "${ovn_multi_network_enable_value}"
+            "<NODES_MTU>" "${ovn_mtu}"
     fi
 
     # Update hbn-configuration.yaml


### PR DESCRIPTION
This is already covered [1] by the provisioner, no need to do it here as
well

1: https://github.com/rh-ecosystem-edge/dpf-hcp-provisioner-operator/blob/293439653d8c2efd58a3926d32f3e24d14249f6d/internal/controller/dpuservicetemplate/dpuservicetemplate.go#L479-L497

