### PR TITLE
TFT: Enable ping_mgmt_port plugin

### DIFF
--- a/ci/tft-config.yaml.template
+++ b/ci/tft-config.yaml.template
@@ -93,8 +93,8 @@ tft:
         #   - measure_cpu      : Measure CPU usage during test
         #   - measure_power    : Measure power consumption
         #   - validate_offload : Verify OvS hardware offload (requires DPU mode)
-        # plugins:
-        #   - name: "measure_cpu"
+        plugins:
+          - ping_mgmt_port
 
         # Secondary Network Configuration (optional)
         # ------------------------------------------


### PR DESCRIPTION
More context in: https://github.com/ovn-kubernetes/kubernetes-traffic-flow-tests/pull/310

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled management-port ping monitoring by default in the standard configuration template.

* **Chores**
  * Removed the unused example plugin configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->