### PR TITLE
tft source .env directly

### DIFF
--- a/scripts/traffic-flow-tests.sh
+++ b/scripts/traffic-flow-tests.sh
@@ -13,7 +13,9 @@ set -e
 set -o pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+set -a
 source "$(dirname "${SCRIPT_DIR}")/.env"
+set +a
 source "${SCRIPT_DIR}/utils.sh"
 
 # -----------------------------------------------------------------------------

--- a/scripts/traffic-flow-tests.sh
+++ b/scripts/traffic-flow-tests.sh
@@ -13,7 +13,7 @@ set -e
 set -o pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "${SCRIPT_DIR}/env.sh"
+source "$(dirname "${SCRIPT_DIR}")/.env"
 source "${SCRIPT_DIR}/utils.sh"
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
There is no need to run `env.sh` which adds an extra `aicli` dependency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Traffic flow tests now load environment settings from the project’s parent-level configuration file, improving test setup consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->