### PR TITLE
tft source .env directly (2)

### DIFF
--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -106,23 +106,24 @@ validate_mtu() {
     fi
 }
 
-# Load environment variables from .env file (skip if already in Make context)
+# Load environment variables from .env file and validate aicli connectivity
+# (skip if already in Make context — the Makefile does `include .env` + `export`)
 if [ -z "${MAKELEVEL:-}" ]; then
     load_env
     validate_mtu
-fi
 
-# aicli uses HOME to find ~/.aicli/offlinetoken.txt. Default: $HOME. Override with AICLI_HOME (e.g. in .env).
-# When using AICLI_HOME, OPENSHIFT_PULL_SECRET must be a pull secret for the same Red Hat account as that token.
-AICLI_HOME=${AICLI_HOME:-$HOME}
-if [[ "$AICLI_HOME" != "$HOME" ]] && [[ ! -f "${AICLI_HOME}/.aicli/offlinetoken.txt" ]]; then
-    echo "Error: ${AICLI_HOME}/.aicli/offlinetoken.txt not found." >&2
-    exit 1
-fi
-export HOME="${AICLI_HOME}"
-if ! aicli list clusters &>/dev/null; then
-    echo "Error: aicli list clusters failed. Check token at ${AICLI_HOME}/.aicli/offlinetoken.txt and connectivity." >&2
-    exit 1
+    # aicli uses HOME to find ~/.aicli/offlinetoken.txt. Default: $HOME. Override with AICLI_HOME (e.g. in .env).
+    # When using AICLI_HOME, OPENSHIFT_PULL_SECRET must be a pull secret for the same Red Hat account as that token.
+    AICLI_HOME=${AICLI_HOME:-$HOME}
+    if [[ "$AICLI_HOME" != "$HOME" ]] && [[ ! -f "${AICLI_HOME}/.aicli/offlinetoken.txt" ]]; then
+        echo "Error: ${AICLI_HOME}/.aicli/offlinetoken.txt not found." >&2
+        exit 1
+    fi
+    export HOME="${AICLI_HOME}"
+    if ! aicli list clusters &>/dev/null; then
+        echo "Error: aicli list clusters failed. Check token at ${AICLI_HOME}/.aicli/offlinetoken.txt and connectivity." >&2
+        exit 1
+    fi
 fi
 
 # Computed / conditional variables — derived from .env values at runtime.


### PR DESCRIPTION
There is no need to run env.sh which adds an extra aicli dependency. Continuation of https://github.com/rh-ecosystem-edge/openshift-dpf/pull/265

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved environment setup reliability when running commands outside Make.
  - Added clearer validation for required CLI credentials and connectivity.
  - Reports actionable errors when credentials are missing or cluster access cannot be verified.
- **Chores**
  - Streamlined environment loading for Make-based workflows to avoid unnecessary validation steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->