### PR TITLE
Add python311 to Containerfile

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -8,7 +8,7 @@ USER root
 # Copying oc binary
 COPY --from=oc-cli /usr/bin/oc /usr/bin/oc
 
-RUN dnf install -y make git jq findutils openssh-clients rsync && dnf clean all
+RUN dnf install -y make git jq findutils openssh-clients rsync python3.11 python3.11-pip python3.11-devel && dnf clean all
 
 # Get the source code in there
 WORKDIR /root/dpf-ci


### PR DESCRIPTION
Needed for running tft from the image

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the container environment to include Python 3.11, pip, and development headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->