### PR TITLE
Containerfile with kubectl

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -7,6 +7,7 @@ USER root
 
 # Copying oc binary
 COPY --from=oc-cli /usr/bin/oc /usr/bin/oc
+RUN ln -s /usr/bin/oc /usr/bin/kubectl
 
 RUN dnf install -y make git jq findutils openssh-clients rsync python3.11 python3.11-pip python3.11-devel && dnf clean all
 


### PR DESCRIPTION
Tft requires the `kubectl` client and not the `oc` one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `kubectl` command as an alias for the included `oc` command, enabling Kubernetes-compatible command usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->