### PR TITLE
Restart OVS only when DPUFlavor config actually changes

### DIFF
--- a/manifests/post-installation/dpuflavor-1500.yaml
+++ b/manifests/post-installation/dpuflavor-1500.yaml
@@ -36,25 +36,50 @@ spec:
         - LINK_TYPE_P2=ETH
   ovs:
     rawConfigScript: |
+      #!/bin/bash
+      set -e
+
       _ovs-vsctl() {
         ovs-vsctl --timeout 15 "$@"
       }
 
-      _ovs-vsctl set Open_vSwitch . other_config:doca-init=true
-      _ovs-vsctl set Open_vSwitch . other_config:dpdk-max-memzones=50000
-      _ovs-vsctl set Open_vSwitch . other_config:hw-offload=true
-      _ovs-vsctl set Open_vSwitch . other_config:pmd-quiet-idle=true
-      _ovs-vsctl set Open_vSwitch . other_config:max-idle=20000
-      _ovs-vsctl set Open_vSwitch . other_config:max-revalidator=5000
-      _ovs-vsctl set Open_vSwitch . other_config:doca-congestion-threshold=60
-      _ovs-vsctl set Open_vSwitch . other_config:flow-limit=500000
-      _ovs-vsctl set Open_vSwitch . other_config:hw-offload-ct-unidir-udp-enabled=true
-      _ovs-vsctl remove Open_vSwitch . other_config default-datapath-type || true
+      restart_ovs=false
 
-      if systemctl list-unit-files openvswitch-switch.service &>/dev/null; then
-        systemctl restart openvswitch-switch
-      elif systemctl list-unit-files openvswitch.service &>/dev/null; then
-        systemctl restart openvswitch
+      _ovs-get-other-config() {
+        _ovs-vsctl --if-exists get Open_vSwitch . "other_config:$1" 2>/dev/null | tr -d '"'
+      }
+
+      _ovs-set-other-config() {
+        if [ "$(_ovs-get-other-config "$1")" != "$2" ]; then
+          _ovs-vsctl set Open_vSwitch . "other_config:$1=$2"
+          restart_ovs=true
+        fi
+      }
+
+      _ovs-remove-other-config() {
+        if [ -n "$(_ovs-get-other-config "$1")" ]; then
+          _ovs-vsctl remove Open_vSwitch . other_config "$1"
+          restart_ovs=true
+        fi
+      }
+
+      _ovs-set-other-config doca-init true
+      _ovs-set-other-config dpdk-max-memzones 50000
+      _ovs-set-other-config hw-offload true
+      _ovs-set-other-config pmd-quiet-idle true
+      _ovs-set-other-config max-idle 20000
+      _ovs-set-other-config max-revalidator 5000
+      _ovs-set-other-config doca-congestion-threshold 60
+      _ovs-set-other-config flow-limit 500000
+      _ovs-set-other-config hw-offload-ct-unidir-udp-enabled true
+      _ovs-remove-other-config default-datapath-type
+
+      if [ "$restart_ovs" = true ]; then
+        if systemctl list-unit-files openvswitch-switch.service &>/dev/null; then
+          systemctl restart openvswitch-switch
+        elif systemctl list-unit-files openvswitch.service &>/dev/null; then
+          systemctl restart openvswitch
+        fi
       fi
 
       _ovs-vsctl --may-exist add-br br-sfc

--- a/manifests/post-installation/dpuflavor-9000.yaml
+++ b/manifests/post-installation/dpuflavor-9000.yaml
@@ -37,25 +37,50 @@ spec:
         - LINK_TYPE_P2=ETH
   ovs:
     rawConfigScript: |
+      #!/bin/bash
+      set -e
+
       _ovs-vsctl() {
         ovs-vsctl --timeout 15 "$@"
       }
 
-      _ovs-vsctl set Open_vSwitch . other_config:doca-init=true
-      _ovs-vsctl set Open_vSwitch . other_config:dpdk-max-memzones=50000
-      _ovs-vsctl set Open_vSwitch . other_config:hw-offload=true
-      _ovs-vsctl set Open_vSwitch . other_config:pmd-quiet-idle=true
-      _ovs-vsctl set Open_vSwitch . other_config:max-idle=20000
-      _ovs-vsctl set Open_vSwitch . other_config:max-revalidator=5000
-      _ovs-vsctl set Open_vSwitch . other_config:doca-congestion-threshold=60
-      _ovs-vsctl set Open_vSwitch . other_config:flow-limit=500000
-      _ovs-vsctl set Open_vSwitch . other_config:hw-offload-ct-unidir-udp-enabled=true
-      _ovs-vsctl remove Open_vSwitch . other_config default-datapath-type || true
+      restart_ovs=false
 
-      if systemctl list-unit-files openvswitch-switch.service &>/dev/null; then
-        systemctl restart openvswitch-switch
-      elif systemctl list-unit-files openvswitch.service &>/dev/null; then
-        systemctl restart openvswitch
+      _ovs-get-other-config() {
+        _ovs-vsctl --if-exists get Open_vSwitch . "other_config:$1" 2>/dev/null | tr -d '"'
+      }
+
+      _ovs-set-other-config() {
+        if [ "$(_ovs-get-other-config "$1")" != "$2" ]; then
+          _ovs-vsctl set Open_vSwitch . "other_config:$1=$2"
+          restart_ovs=true
+        fi
+      }
+
+      _ovs-remove-other-config() {
+        if [ -n "$(_ovs-get-other-config "$1")" ]; then
+          _ovs-vsctl remove Open_vSwitch . other_config "$1"
+          restart_ovs=true
+        fi
+      }
+
+      _ovs-set-other-config doca-init true
+      _ovs-set-other-config dpdk-max-memzones 50000
+      _ovs-set-other-config hw-offload true
+      _ovs-set-other-config pmd-quiet-idle true
+      _ovs-set-other-config max-idle 20000
+      _ovs-set-other-config max-revalidator 5000
+      _ovs-set-other-config doca-congestion-threshold 60
+      _ovs-set-other-config flow-limit 500000
+      _ovs-set-other-config hw-offload-ct-unidir-udp-enabled true
+      _ovs-remove-other-config default-datapath-type
+
+      if [ "$restart_ovs" = true ]; then
+        if systemctl list-unit-files openvswitch-switch.service &>/dev/null; then
+          systemctl restart openvswitch-switch
+        elif systemctl list-unit-files openvswitch.service &>/dev/null; then
+          systemctl restart openvswitch
+        fi
       fi
 
       _ovs-vsctl --may-exist add-br br-sfc


### PR DESCRIPTION
The dpf-ovs script set every Open_vSwitch other_config key unconditionally and then always bounced openvswitch, so every reconcile tore down the datapath even when nothing had changed. Read each key first and only write it when the value differs, tracking whether anything changed in restart_ovs; the restart now runs only when that flag is set.

Also add a #shebang and set -e so a failed restart or ovs-vsctl command fails the unit instead of letting the rest of the script run against a dead OVS. This drops the || true on the default-datapath-type removal, which is now only attempted when the key is present.

Applied identically to both the 1500 and 9000 flavors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Open vSwitch configuration reliability by applying settings only when changes are needed.
  * Removed outdated configuration values when present.
  * Prevented unnecessary service restarts, while retaining compatibility with supported Open vSwitch service names.
  * Added safer handling for configuration errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->