### PR TITLE
Bump default OpenShift version to 4.22.7

### DIFF
--- a/ci/env.defaults
+++ b/ci/env.defaults
@@ -6,7 +6,7 @@
 # Syntax: ${VAR:-default} means "use default if VAR is unset or empty"
 
 # Cluster Configuration
-OPENSHIFT_VERSION=${OPENSHIFT_VERSION:-4.22.2}
+OPENSHIFT_VERSION=${OPENSHIFT_VERSION:-4.22.7}
 OLM_WORKAROUND=${OLM_WORKAROUND:-true}
 
 # Bridge Configuration
@@ -48,7 +48,7 @@ HYPERSHIFT_IMAGE=${HYPERSHIFT_IMAGE:-quay.io/hypershift/hypershift-operator:late
 HOSTED_CLUSTER_NAME=${HOSTED_CLUSTER_NAME:-doca}
 CLUSTERS_NAMESPACE=${CLUSTERS_NAMESPACE:-clusters}
 HOSTED_CONTROL_PLANE_NAMESPACE=${HOSTED_CONTROL_PLANE_NAMESPACE:-clusters-doca}
-OCP_RELEASE_IMAGE=${OCP_RELEASE_IMAGE:-quay.io/openshift-release-dev/ocp-release:4.22.2-multi}
+OCP_RELEASE_IMAGE=${OCP_RELEASE_IMAGE:-quay.io/openshift-release-dev/ocp-release:4.22.7-multi}
 DISABLE_HCP_CAPS=${DISABLE_HCP_CAPS:-false}
 DPF_CLUSTER_TYPE=${DPF_CLUSTER_TYPE:-hypershift}
 


### PR DESCRIPTION
## Summary
- Update default `OPENSHIFT_VERSION` from 4.22.2 to 4.22.7
- Update default `OCP_RELEASE_IMAGE` to match (4.22.7-multi)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default OpenShift version to 4.22.7.
  * Updated the associated release image to match the new version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->