### PR TITLE
E2E: add TC-INST-003 mixed DPU and non-DPU worker validation

### DIFF
--- a/test/e2e/helpers_mixed_workers_test.go
+++ b/test/e2e/helpers_mixed_workers_test.go
@@ -1,0 +1,87 @@
+package e2e
+
+import (
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/openshift-dpf/test/manifests"
+	"github.com/openshift-dpf/test/utils"
+)
+
+// verifyMixedWorkerEastWestConnectivity applies dedicated DPU-worker and regular-worker workloads,
+// waits for a running pod on each worker type, verifies bidirectional east-west ping connectivity
+// across the node boundary, then cleans up both workloads. Reusable by any mixed-worker test case.
+func verifyMixedWorkerEastWestConnectivity() {
+	By("Applying DPU-worker workload manifests (sriov-test-worker)")
+	Expect(utils.ApplyManifests(ctx, mgmtClient, manifests.WorkloadManifestBytes())).To(Succeed())
+
+	By("Applying regular-worker workload manifests (connectivity-test-regular-worker)")
+	Expect(utils.ApplyManifests(ctx, mgmtClient, manifests.RegularWorkerWorkloadManifestBytes())).To(Succeed())
+
+	DeferCleanup(func() {
+		var cleanupErrs []error
+		By("Removing DPU-worker workload manifests")
+		if err := utils.DeleteManifests(ctx, mgmtClient, manifests.WorkloadManifestBytes()); err != nil {
+			cleanupErrs = append(cleanupErrs, fmt.Errorf("DPU-worker workload cleanup: %w", err))
+		}
+		By("Removing regular-worker workload manifests")
+		if err := utils.DeleteManifests(ctx, mgmtClient, manifests.RegularWorkerWorkloadManifestBytes()); err != nil {
+			cleanupErrs = append(cleanupErrs, fmt.Errorf("regular-worker workload cleanup: %w", err))
+		}
+		Expect(cleanupErrs).To(BeEmpty(), "workload cleanup failures will affect subsequent tests")
+	})
+
+	By("Waiting for at least one connectivity-test-regular-worker pod to be Running")
+	var regularPod corev1.Pod
+	Eventually(func(g Gomega) {
+		pods, err := utils.GetRunningPods(ctx, mgmtClient, cfg.WorkloadNamespace,
+			map[string]string{"app": "connectivity-test-regular-worker"})
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(pods).NotTo(BeEmpty(), "no Running connectivity-test-regular-worker pods found")
+		regularPod = pods[0]
+	}).WithTimeout(5 * time.Minute).WithPolling(10 * time.Second).Should(Succeed())
+	GinkgoWriter.Printf("Regular-worker pod: %s on node %s (IP: %s)\n",
+		regularPod.Name, regularPod.Spec.NodeName, regularPod.Status.PodIP)
+
+	By("Waiting for at least one sriov-test-worker pod to be Running on a DPU worker")
+	var dpuWorkerPod corev1.Pod
+	Eventually(func(g Gomega) {
+		pods, err := utils.GetRunningPods(ctx, mgmtClient, cfg.WorkloadNamespace,
+			map[string]string{"app": "sriov-test-worker"})
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(pods).NotTo(BeEmpty(), "no Running sriov-test-worker pods found")
+		dpuWorkerPod = pods[0]
+	}).WithTimeout(5 * time.Minute).WithPolling(10 * time.Second).Should(Succeed())
+
+	dpuHostWorkerNames := make(map[string]struct{}, len(dpuHostWorkers))
+	for _, n := range dpuHostWorkers {
+		dpuHostWorkerNames[n.Name] = struct{}{}
+	}
+	Expect(dpuHostWorkerNames).To(HaveKey(dpuWorkerPod.Spec.NodeName),
+		"sriov-test-worker pod %s scheduled on node %s which is not a DPU-enabled worker; "+
+			"the DPU workload must run on DPU nodes to correctly test the mixed-worker connectivity path",
+		dpuWorkerPod.Name, dpuWorkerPod.Spec.NodeName)
+	GinkgoWriter.Printf("DPU-worker pod: %s on node %s (IP: %s)\n",
+		dpuWorkerPod.Name, dpuWorkerPod.Spec.NodeName, dpuWorkerPod.Status.PodIP)
+
+	By(fmt.Sprintf("East-west ping: regular-worker pod %s → DPU-worker pod %s (%s)",
+		regularPod.Name, dpuWorkerPod.Name, dpuWorkerPod.Status.PodIP))
+	Expect(utils.PingFromPod(ctx, mgmtConfig, mgmtClientset,
+		cfg.WorkloadNamespace, regularPod.Name, "netshoot",
+		dpuWorkerPod.Status.PodIP, cfg.PingCount, 0)).To(Succeed())
+
+	By(fmt.Sprintf("East-west ping: DPU-worker pod %s → regular-worker pod %s (%s)",
+		dpuWorkerPod.Name, regularPod.Name, regularPod.Status.PodIP))
+	Expect(utils.PingFromPod(ctx, mgmtConfig, mgmtClientset,
+		cfg.WorkloadNamespace, dpuWorkerPod.Name, "nginx",
+		regularPod.Status.PodIP, cfg.PingCount, 0)).To(Succeed())
+
+	GinkgoWriter.Printf("East-west connectivity verified: %s (%s) ↔ %s (%s)\n",
+		regularPod.Spec.NodeName, regularPod.Status.PodIP,
+		dpuWorkerPod.Spec.NodeName, dpuWorkerPod.Status.PodIP)
+}

--- a/test/e2e/installation_mixed_workers_test.go
+++ b/test/e2e/installation_mixed_workers_test.go
@@ -1,0 +1,214 @@
+package e2e
+
+import (
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	dpfe2e "github.com/nvidia/doca-platform/test/e2e"
+
+	provisioningv1 "github.com/nvidia/doca-platform/api/provisioning/v1alpha1"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/openshift-dpf/test/utils"
+)
+
+// TC-INST-003: Validate DPF on OCP 4.22.z Operates a Cluster with a Mix of DPU Workers and Non-DPU Workers
+//
+// Verifies that DPF correctly scopes DPU provisioning and services to DPU-enabled host
+// worker nodes only, leaving regular (non-DPU) workers untouched and fully schedulable.
+var _ = Describe("TC-INST-003: Validate DPF on OCP Operates a Cluster with a Mix of DPU Workers and Non-DPU Workers", Label("deployment", "installation-mixed-workers"), Ordered, func() {
+
+	BeforeAll(func() {
+		if dpfInput.NumberOfDPUNodes == 0 {
+			Skip("No DPU nodes available, skipping TC-INST-003")
+		}
+	})
+
+	It("pre-condition: should have both DPU-enabled and non-DPU worker nodes present", func() {
+		By("Listing all ready worker nodes in management cluster")
+		allWorkers, err := utils.GetReadyWorkerNodes(ctx, mgmtClient)
+		Expect(err).NotTo(HaveOccurred())
+
+		var dpuEnabledWorkers, nonDPUWorkers []corev1.Node
+		for _, n := range allWorkers {
+			if _, ok := n.Labels[utils.DPUEnabledLabel]; ok {
+				dpuEnabledWorkers = append(dpuEnabledWorkers, n)
+			} else {
+				nonDPUWorkers = append(nonDPUWorkers, n)
+			}
+		}
+
+		GinkgoWriter.Printf("Worker nodes — DPU-enabled: %d, non-DPU: %d (total: %d)\n",
+			len(dpuEnabledWorkers), len(nonDPUWorkers), len(allWorkers))
+		for _, n := range dpuEnabledWorkers {
+			GinkgoWriter.Printf("  DPU-enabled: %s\n", n.Name)
+		}
+		for _, n := range nonDPUWorkers {
+			GinkgoWriter.Printf("  non-DPU:     %s\n", n.Name)
+		}
+
+		Expect(dpuEnabledWorkers).NotTo(BeEmpty(),
+			"cluster must have at least one DPU-enabled worker node")
+		if len(nonDPUWorkers) == 0 {
+			Skip("no non-DPU worker nodes found; TC-INST-003 requires a mixed-worker cluster")
+		}
+	})
+
+	It("pre-condition: should have DPUDeployment in Ready state", func() {
+		Eventually(func(g Gomega) {
+			dpuDeployment := getDPUDeployment()
+			g.Expect(isReady(dpuDeployment.Status.Conditions)).To(BeTrue(),
+				"DPUDeployment must be Ready before mixed-worker cluster validation")
+		}).WithTimeout(dpfe2e.DPUDeploymentReadyTimeout).WithPolling(5 * time.Second).Should(Succeed())
+	})
+
+	It("should have DPU objects provisioned only on DPU-enabled nodes", func() {
+		By("Listing all DPU objects in DPF namespace")
+		dpuList := &provisioningv1.DPUList{}
+		Expect(mgmtClient.List(ctx, dpuList, client.InNamespace(cfg.DPFNamespace))).To(Succeed())
+
+		dpuEnabledNames := make(map[string]struct{}, len(dpuHostWorkers))
+		for _, n := range dpuHostWorkers {
+			dpuEnabledNames[n.Name] = struct{}{}
+		}
+
+		for _, dpu := range dpuList.Items {
+			nodeName := dpu.Spec.DPUNodeName
+			GinkgoWriter.Printf("DPU %s → node %s (phase: %s)\n", dpu.Name, nodeName, dpu.Status.Phase)
+			Expect(dpuEnabledNames).To(HaveKey(nodeName),
+				"DPU %s is on node %s which is not a DPU-enabled host worker; "+
+					"DPU provisioning must not target non-DPU nodes in a mixed cluster",
+				dpu.Name, nodeName)
+		}
+		GinkgoWriter.Printf("All %d DPU object(s) are confined to DPU-enabled nodes\n", len(dpuList.Items))
+	})
+
+	It("should have all DPU objects in Ready phase", func() {
+		dpuList := &provisioningv1.DPUList{}
+		Expect(mgmtClient.List(ctx, dpuList, client.InNamespace(cfg.DPFNamespace))).To(Succeed())
+
+		dpuByNode := make(map[string]provisioningv1.DPU, len(dpuList.Items))
+		for _, dpu := range dpuList.Items {
+			dpuByNode[dpu.Spec.DPUNodeName] = dpu
+		}
+
+		for _, n := range dpuHostWorkers {
+			dpu, ok := dpuByNode[n.Name]
+			Expect(ok).To(BeTrue(),
+				"no DPU object found for DPU-enabled worker node %s", n.Name)
+			Expect(dpu.Status.Phase).To(Equal(provisioningv1.DPUReady),
+				"DPU %s on node %s should be in Ready phase, got %q",
+				dpu.Name, n.Name, dpu.Status.Phase)
+			GinkgoWriter.Printf("DPU %s on node %s: Ready\n", dpu.Name, n.Name)
+		}
+		GinkgoWriter.Printf("%d DPU object(s) verified Ready (one per DPU-enabled worker)\n", len(dpuHostWorkers))
+	})
+
+	It("should have DPU worker nodes labeled with the worker-dpu role", func() {
+		for _, n := range dpuHostWorkers {
+			By(fmt.Sprintf("Checking node %s has worker-dpu role label", n.Name))
+			Expect(n.Labels).To(HaveKey("node-role.kubernetes.io/worker-dpu"),
+				"DPU host worker %s must have the worker-dpu role label; "+
+					"the MCP assigns this label during DPU provisioning",
+				n.Name)
+		}
+		GinkgoWriter.Printf("All %d DPU host worker(s) carry the worker-dpu role label\n", len(dpuHostWorkers))
+	})
+
+	It("should have Updated, non-Degraded MachineConfigPools for each worker type", func() {
+		mcpList := &unstructured.UnstructuredList{}
+		mcpList.SetGroupVersionKind(schema.GroupVersionKind{
+			Group:   "machineconfiguration.openshift.io",
+			Version: "v1",
+			Kind:    "MachineConfigPoolList",
+		})
+		Expect(mgmtClient.List(ctx, mcpList)).To(Succeed())
+
+		mcpByName := map[string]unstructured.Unstructured{}
+		for _, mcp := range mcpList.Items {
+			mcpByName[mcp.GetName()] = mcp
+		}
+
+		for _, poolName := range []string{"worker", "worker-dpu"} {
+			By(fmt.Sprintf("Checking MachineConfigPool %q exists and is healthy", poolName))
+			mcp, ok := mcpByName[poolName]
+			Expect(ok).To(BeTrue(), "MachineConfigPool %q must exist in a mixed-worker cluster", poolName)
+
+			conditions, _, _ := unstructured.NestedSlice(mcp.Object, "status", "conditions")
+			var updating, degraded, updated bool
+			for _, raw := range conditions {
+				cond, _ := raw.(map[string]interface{})
+				t, _, _ := unstructured.NestedString(cond, "type")
+				s, _, _ := unstructured.NestedString(cond, "status")
+				switch t {
+				case "Updating":
+					updating = s == "True"
+				case "Degraded":
+					degraded = s == "True"
+				case "Updated":
+					updated = s == "True"
+				}
+			}
+			Expect(updating).To(BeFalse(),
+				"MachineConfigPool %q must not be Updating", poolName)
+			Expect(degraded).To(BeFalse(),
+				"MachineConfigPool %q must not be Degraded", poolName)
+			Expect(updated).To(BeTrue(),
+				"MachineConfigPool %q must have Updated=True", poolName)
+
+			mc, _, _ := unstructured.NestedInt64(mcp.Object, "status", "machineCount")
+			ready, _, _ := unstructured.NestedInt64(mcp.Object, "status", "readyMachineCount")
+			GinkgoWriter.Printf("MCP %q: machineCount=%d readyMachineCount=%d\n", poolName, mc, ready)
+			Expect(ready).To(Equal(mc),
+				"MachineConfigPool %q: readyMachineCount (%d) must equal machineCount (%d)",
+				poolName, ready, mc)
+		}
+
+		By("Verifying worker-dpu MCP machine count matches DPU host worker count")
+		dpuMCP := mcpByName["worker-dpu"]
+		dpuMCPCount, _, _ := unstructured.NestedInt64(dpuMCP.Object, "status", "machineCount")
+		Expect(int(dpuMCPCount)).To(Equal(len(dpuHostWorkers)),
+			"worker-dpu MCP machineCount (%d) must equal the number of DPU host workers (%d)",
+			dpuMCPCount, len(dpuHostWorkers))
+	})
+
+	It("should deploy workloads on non-DPU workers and verify east-west connectivity to DPU workers", func() {
+		verifyMixedWorkerEastWestConnectivity()
+	})
+
+	It("should have no DPU-specific taints on non-DPU worker nodes", func() {
+		By("Listing all ready worker nodes")
+		allWorkers, err := utils.GetReadyWorkerNodes(ctx, mgmtClient)
+		Expect(err).NotTo(HaveOccurred())
+
+		dpuEnabledSet := make(map[string]struct{}, len(dpuHostWorkers))
+		for _, n := range dpuHostWorkers {
+			dpuEnabledSet[n.Name] = struct{}{}
+		}
+
+		for _, worker := range allWorkers {
+			if _, isDPU := dpuEnabledSet[worker.Name]; isDPU {
+				continue
+			}
+			By(fmt.Sprintf("Checking non-DPU worker %s for DPU-specific taints", worker.Name))
+			for _, taint := range worker.Spec.Taints {
+				Expect(taint.Key).NotTo(HavePrefix("dpu.nvidia.com/"),
+					"non-DPU worker %s must not carry DPU-specific taint %q (value=%q, effect=%q); "+
+						"DPU taints must be confined to DPU-enabled nodes",
+					worker.Name, taint.Key, taint.Value, taint.Effect)
+			}
+			GinkgoWriter.Printf("Non-DPU worker %s: no DPU-specific taints\n", worker.Name)
+		}
+	})
+
+	It("should have a healthy cluster in mixed-worker configuration", func() {
+		waitForClusterHealth()
+	})
+})

--- a/test/manifests/regular_worker_workload.go
+++ b/test/manifests/regular_worker_workload.go
@@ -1,0 +1,10 @@
+package manifests
+
+import _ "embed"
+
+//go:embed regular_worker_workload.yaml
+var regularWorkerWorkloadYAML []byte
+
+func RegularWorkerWorkloadManifestBytes() []byte {
+	return regularWorkerWorkloadYAML
+}

--- a/test/manifests/regular_worker_workload.yaml
+++ b/test/manifests/regular_worker_workload.yaml
@@ -1,0 +1,55 @@
+# Deployment: connectivity-test-regular-worker
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: connectivity-test-regular-worker
+  namespace: workload
+  labels:
+    app: connectivity-test-regular-worker
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: connectivity-test-regular-worker
+  template:
+    metadata:
+      labels:
+        app: connectivity-test-regular-worker
+    spec:
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: DoNotSchedule
+        labelSelector:
+          matchLabels:
+            app: connectivity-test-regular-worker
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/worker
+                operator: Exists
+              - key: feature.node.kubernetes.io/dpu-enabled
+                operator: DoesNotExist
+              - key: node-role.kubernetes.io/control-plane
+                operator: DoesNotExist
+      containers:
+      - name: netshoot
+        securityContext:
+          capabilities:
+            add:
+            - NET_RAW
+        image: quay.io/wabouham/ecosys-nvidia/nicolaka-netshoot:latest
+        command: ["nc", "-kl", "5000"]
+        ports:
+        - containerPort: 5000
+          name: tcp-server
+        resources:
+          requests:
+            cpu: 1
+            memory: 1Gi
+          limits:
+            cpu: 1
+            memory: 1Gi

--- a/test/utils/resource.go
+++ b/test/utils/resource.go
@@ -62,6 +62,9 @@ func ApplyManifests(ctx context.Context, c client.Client, manifestBytes []byte) 
 		if err := yaml.NewYAMLOrJSONDecoder(bytes.NewReader(doc), len(doc)).Decode(obj); err != nil {
 			return fmt.Errorf("decoding YAML: %w", err)
 		}
+		if obj.GetKind() == "" {
+			continue
+		}
 
 		existing := obj.DeepCopy()
 		err = c.Get(ctx, client.ObjectKeyFromObject(obj), existing)
@@ -76,6 +79,39 @@ func ApplyManifests(ctx context.Context, c client.Client, manifestBytes []byte) 
 			if err := c.Update(ctx, obj); err != nil {
 				return fmt.Errorf("updating %s %s/%s: %w", obj.GetKind(), obj.GetNamespace(), obj.GetName(), err)
 			}
+		}
+	}
+	return nil
+}
+
+// DeleteManifests deletes each object described in manifestBytes. Namespace objects are skipped
+// to avoid cascading deletion of other test resources sharing the same namespace.
+// Not-found errors are silently ignored so the function is idempotent.
+func DeleteManifests(ctx context.Context, c client.Client, manifestBytes []byte) error {
+	reader := yaml.NewYAMLReader(bufio.NewReader(bytes.NewReader(manifestBytes)))
+	for {
+		doc, err := reader.Read()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("reading YAML document: %w", err)
+		}
+		doc = bytes.TrimSpace(doc)
+		if len(doc) == 0 {
+			continue
+		}
+
+		obj := &unstructured.Unstructured{}
+		if err := yaml.NewYAMLOrJSONDecoder(bytes.NewReader(doc), len(doc)).Decode(obj); err != nil {
+			return fmt.Errorf("decoding YAML: %w", err)
+		}
+		if obj.GetKind() == "" || obj.GetKind() == "Namespace" {
+			continue
+		}
+
+		if err := c.Delete(ctx, obj); err != nil && !errors.IsNotFound(err) {
+			return fmt.Errorf("deleting %s %s/%s: %w", obj.GetKind(), obj.GetNamespace(), obj.GetName(), err)
 		}
 	}
 	return nil


### PR DESCRIPTION
## Summary

Implements TC-INST-003: validates that DPF correctly operates a cluster containing both DPU-enabled and regular (non-DPU) worker nodes.

The test asserts:
- Both DPU-enabled workers and non-DPU workers are present (pre-condition for mixed-worker clusters)
- DPUDeployment is in Ready state before validation
- DPU objects are provisioned **only** on DPU-enabled nodes (no spillover onto regular workers)
- All DPU objects are in Ready phase
- Non-DPU worker nodes carry no `dpu.nvidia.com/` taints that would block normal workload scheduling
- Cluster operators are healthy after the checks
- east-west connectivity check

## Test plan
- [x] Run against a cluster profile with at least 1 DPU-enabled worker and 1 regular worker

```
$ HOSTED_CLUSTER_NAME=doca make test-go-e2e E2E_GO_LABEL_FILTER=installation-mixed-workers    
...

Ran 9 of 91 Specs in 50.872 seconds
SUCCESS! -- 9 Passed | 0 Failed | 0 Pending | 82 Skipped
--- PASS: TestE2E (50.87s)
PASS
ok      github.com/openshift-dpf/test/e2e       50.917s
```


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end coverage for clusters combining DPU-enabled and standard workers.
  * Validates deployment readiness, DPU placement and status, worker roles and configuration, workload connectivity, and overall cluster health.
  * Added cleanup support for test workloads and improved handling of manifest application and deletion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->