### PR TITLE
Proxy deployment for remote cluster access

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -387,6 +387,11 @@ delete-dpf-hcp-provisioner-operator:
 	@echo "Deleting DPF HCP Provisioner Operator..."
 	@$(DPF_SCRIPT) delete-dpf-hcp-provisioner-operator
 
+# Proxy for remote cluster access
+.PHONY: deploy-proxy
+deploy-proxy:
+	@scripts/proxy/deploy.sh
+
 # Verification targets
 .PHONY: verify-deployment
 verify-deployment:
@@ -471,6 +476,9 @@ help:
 	@echo "  deploy-csr-approver - Deploy CSR auto-approver CronJob for host cluster workers"
 	@echo "  delete-csr-approver - Remove CSR auto-approver from host cluster"
 	@echo "  delete-dpf-hcp-provisioner-operator - Remove DPF HCP Provisioner Operator and related resources"
+	@echo ""
+	@echo "Remote Access:"
+	@echo "  deploy-proxy      - Deploy squid proxy on hypervisor for remote cluster access"
 	@echo ""
 	@echo "Verification:"
 	@echo "  verify-deployment     - Full verification: workers + DPU nodes + DPUDeployment"

--- a/ci/proxy-conf.sh.template
+++ b/ci/proxy-conf.sh.template
@@ -1,0 +1,6 @@
+# Based on openshift/release baremetalds-devscripts-proxy:
+# https://github.com/openshift/release/blob/5664a0bdb7ac/ci-operator/step-registry/baremetalds/devscripts/proxy/baremetalds-devscripts-proxy-commands.sh#L80-L89
+export HTTPS_PROXY=http://${REMOTE_HOST}:${PROXY_PORT}/
+export NO_PROXY="static.redhat.com,redhat.io,quay.io,openshift.org,openshift.com,svc,amazonaws.com,r2.cloudflarestorage.com,github.com,githubusercontent.com,google.com,googleapis.com,fedoraproject.org,cloudfront.net,workers.dev,localhost,127.0.0.1"
+export https_proxy=http://${REMOTE_HOST}:${PROXY_PORT}/
+export no_proxy="static.redhat.com,redhat.io,quay.io,openshift.org,openshift.com,svc,amazonaws.com,r2.cloudflarestorage.com,github.com,githubusercontent.com,google.com,googleapis.com,fedoraproject.org,cloudfront.net,workers.dev,localhost,127.0.0.1"

--- a/scripts/proxy/deploy.sh
+++ b/scripts/proxy/deploy.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+#
+# Deploy a squid proxy for the cluster and produce a kubeconfig with
+# the ingress CA appended. Run on the hypervisor via 'make deploy-proxy'.
+#
+# Requires: KUBECONFIG
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+PROXY_PORT=8213
+KUBECONFIG_DIR="$(cd "$(dirname "${KUBECONFIG}")" && pwd)"
+OUTPUT_KUBECONFIG="${OUTPUT_KUBECONFIG:-kubeconfig.proxy}"
+
+deploy_proxy() {
+	CLUSTER_DOMAIN="$(oc config view --minify \
+		-o jsonpath='{.clusters[0].cluster.server}' | sed -E 's#https://api\.([^:]+):.*#\1#')"
+
+	SQUID_CONF="${KUBECONFIG_DIR}/dpf-ci-squid.conf"
+	sed -e "s/\${CLUSTER_DOMAIN}/${CLUSTER_DOMAIN}/g" \
+		-e "s/\${PROXY_PORT}/${PROXY_PORT}/g" \
+		"${SCRIPT_DIR}/squid.conf.template" >"${SQUID_CONF}"
+
+	bash "${SCRIPT_DIR}/start-squid.sh" "${SQUID_CONF}"
+
+	echo "Squid proxy listening on :${PROXY_PORT} for *.${CLUSTER_DOMAIN}"
+}
+
+append_ingress_ca() {
+	cp "${KUBECONFIG}" "${OUTPUT_KUBECONFIG}"
+
+	CLUSTER_CTX="$(KUBECONFIG="${OUTPUT_KUBECONFIG}" oc config view --minify -o jsonpath='{.clusters[0].name}')"
+
+	CA_TMPDIR="$(mktemp -d)"
+	trap 'rm -rf "${CA_TMPDIR}"' EXIT
+
+	oc get secret -n openshift-ingress-operator router-ca -o jsonpath='{.data.tls\.crt}' | base64 -d >"${CA_TMPDIR}/ingress-ca.crt"
+	oc config view --raw -o jsonpath='{.clusters[0].cluster.certificate-authority-data}' | base64 -d >"${CA_TMPDIR}/existing-cas.pem"
+
+	cat "${CA_TMPDIR}/existing-cas.pem" "${CA_TMPDIR}/ingress-ca.crt" >"${CA_TMPDIR}/combined-cas.pem"
+
+	KUBECONFIG="${OUTPUT_KUBECONFIG}" oc config set "clusters.${CLUSTER_CTX}.certificate-authority-data" "$(base64 -w0 "${CA_TMPDIR}/combined-cas.pem")"
+}
+
+deploy_proxy
+append_ingress_ca
+
+PROXY_HOST="$(hostname -f 2>/dev/null || hostname)"
+OUTPUT_KUBECONFIG_ABS="$(cd "$(dirname "${OUTPUT_KUBECONFIG}")" && pwd)/$(basename "${OUTPUT_KUBECONFIG}")"
+echo ""
+echo "Kubeconfig with ingress CA: ${OUTPUT_KUBECONFIG_ABS}"
+echo ""
+echo "To use from a remote machine, copy the kubeconfig and set:"
+echo "  export HTTPS_PROXY=http://${PROXY_HOST}:${PROXY_PORT}/"
+echo "  export KUBECONFIG=<local path to kubeconfig.proxy>"

--- a/scripts/proxy/squid.conf.template
+++ b/scripts/proxy/squid.conf.template
@@ -1,0 +1,5 @@
+acl cluster dstdomain .${CLUSTER_DOMAIN}
+acl CONNECT method CONNECT
+http_access allow CONNECT cluster
+http_access deny all
+http_port ${PROXY_PORT}

--- a/scripts/proxy/start-squid.sh
+++ b/scripts/proxy/start-squid.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Run on the hypervisor to (re)start the squid proxy container.
+# Usage: start-squid.sh <path-to-squid.conf>
+set -euo pipefail
+
+SQUID_CONF="${1:?Usage: start-squid.sh <path-to-squid.conf>}"
+
+podman rm -f dpf-ci-squid 2>/dev/null || true
+podman run -d --net host --name dpf-ci-squid \
+	-v "${SQUID_CONF}":/etc/squid/squid.conf:Z \
+	-v /etc/resolv.conf:/etc/resolv.conf:ro \
+	quay.io/openshifttest/squid-proxy:multiarch
+sleep 2
+echo "Squid proxy running"


### PR DESCRIPTION
Accessing the cluster remotely currently requires the user to set up DNS properly, which is not always easy, especially in a CI environment.

Add a new `make deploy-proxy` target that deploys a squid proxy on the hypervisor and produces a kubeconfig with the ingress CA appended (this is good for tests and temporary until we land https://github.com/karmab/aicli/pull/70).

User can then scp the kubeconfig to their local machine and set the HTTPS_PROXY environment variable to point to the hypervisor, allowing them to access the cluster without needing to set up DNS.

Also the CI uses a "proxy-conf.sh" file to set the proxy environment variables for the universal CI steps. I've added a template of this file so our CI can use it without hardcoding it.

Companion PR to be merged after this one https://github.com/openshift/release/pull/83183
