### PR TITLE
[release-4.22] Use 4.22.7-multi by default for the 4.22 release

### DIFF
--- a/ci/env.defaults
+++ b/ci/env.defaults
@@ -6,7 +6,7 @@
 # Syntax: ${VAR:-default} means "use default if VAR is unset or empty"
 
 # Cluster Configuration
-OPENSHIFT_VERSION=${OPENSHIFT_VERSION:-4.22.7}
+OPENSHIFT_VERSION=${OPENSHIFT_VERSION:-4.22.7-multi}
 OLM_WORKAROUND=${OLM_WORKAROUND:-true}
 
 # Bridge Configuration


### PR DESCRIPTION
Use `4.22.7-multi` instead of `4.22.7` by default to enable multi-architecture image access.