### PR TITLE
fix: Raname br-dpu to br-ex and remove unused mtu_flag from dpu-worker-config helm deploy

### DIFF
--- a/manifests/dpf-installation/dpfoperatorconfig.yaml
+++ b/manifests/dpf-installation/dpfoperatorconfig.yaml
@@ -43,3 +43,5 @@ spec:
   networking:
     controlPlaneMTU: <NODES_MTU>
     highSpeedMTU: <NODES_MTU>
+    dpuNodeOOBBridgeName: br-ex
+

--- a/scripts/dpf.sh
+++ b/scripts/dpf.sh
@@ -218,8 +218,7 @@ function deploy_dpu_worker_config() {
         --namespace ${DPF_HCP_PROVISIONER_OPERATOR_NAMESPACE} \
         --create-namespace \
         --disable-openapi-validation \
-        ${version_flag} \
-        ${mtu_flag}; then
+        ${version_flag}; then
         log [INFO] "Helm release 'dpu-worker-config' deployed successfully"
     else
         log [ERROR] "Helm deployment of dpu-worker-config failed"


### PR DESCRIPTION
## Summary

- Remove the unused `${mtu_flag}` parameter from the `dpu-worker-config` helm install command in `deploy_dpu_worker_config()`

## Test plan

- [ ] Verify `make deploy-dpf` still deploys dpu-worker-config chart successfully


Made with [Cursor](https://cursor.com)