### PR TITLE
fix: use dpuNodeSelector, drop redundant BFB fileName

### DIFF
--- a/manifests/post-installation/bfb.yaml
+++ b/manifests/post-installation/bfb.yaml
@@ -5,7 +5,6 @@ metadata:
   name: bf-bundle
   namespace: dpf-operator-system
 spec:
-  fileName: <BFB_FILENAME>
   url: <BFB_URL>
   versions:
     atf: 4.15.0-4-g419fbf393

--- a/manifests/post-installation/dpudeployment.yaml
+++ b/manifests/post-installation/dpudeployment.yaml
@@ -15,7 +15,7 @@ spec:
     - nameSuffix: "dpuset1"
       dpuAnnotations:
         noderesources.dpu.nvidia.com/nodesriovdevicepluginconfig: <SRIOV_DP_CONFIG_CR_NAME>
-      nodeSelector:
+      dpuNodeSelector:
         matchLabels:
           feature.node.kubernetes.io/dpu-enabled: ""
   services:

--- a/scripts/post-install.sh
+++ b/scripts/post-install.sh
@@ -44,13 +44,10 @@ SPECIAL_FILES=(
 # Function to update BFB manifest
 function update_bfb_manifest() {
     log [INFO] "Updating BFB manifest..."
-    # Extract filename from URL
-    local bfb_filename=$(basename "${BFB_URL}")
     # Update the manifest with custom values using update_file_multi_replace
     update_file_multi_replace \
         "${POST_INSTALL_DIR}/bfb.yaml" \
         "${GENERATED_POST_INSTALL_DIR}/bfb.yaml" \
-        "<BFB_FILENAME>" "${bfb_filename}" \
         "<BFB_URL>" "\"${BFB_URL}\""
     log [INFO] "BFB manifest updated successfully"
 }


### PR DESCRIPTION
- DPUDeployment dpuSets.nodeSelector is deprecated and removed in DPF v26.7.0; dpuNodeSelector is an equivalent rename. 
- BFB spec.fileName is optional and DPF derives a unique <namespace>-<name>.bfb when unset.

Both align with upstream DPF conventions and the DPF-on-OpenShift user manual. No behavioral change.
