### PR TITLE
Enable host-network-ready NoExecute taints in DPFOperatorConfig

### DIFF
--- a/manifests/dpf-installation/dpfoperatorconfig.yaml
+++ b/manifests/dpf-installation/dpfoperatorconfig.yaml
@@ -44,4 +44,6 @@ spec:
     controlPlaneMTU: <NODES_MTU>
     highSpeedMTU: <NODES_MTU>
     dpuNodeOOBBridgeName: br-ex
+  dpuServiceController:
+    disableHostNetworkReadyNoExecuteTaints: false
 


### PR DESCRIPTION
## Summary
- Opt in to DPF host-network-ready NoExecute taints on `DPFOperatorConfig` by setting `dpuServiceController.disableHostNetworkReadyNoExecuteTaints: false`.
- The feature is disabled by default; this enables tainting host worker nodes when a Ready-phase DPU reports `HostNetworkReady` is not `True`, so workloads that depend on host VFs are evicted until host networking is ready.

## Test plan
- [ ] Apply `DPFOperatorConfig` and confirm `spec.dpuServiceController.disableHostNetworkReadyNoExecuteTaints` is `false`.
- [ ] Confirm DPF dpu-service-controller is started with `--disable-host-network-ready-noexecute-taints=false`.
- [ ] When a DPU reports `HostNetworkReady != True`, the corresponding host worker is NoExecute-tainted and dependent workloads are evicted.
- [ ] When `HostNetworkReady` becomes `True`, the taint is removed and workloads can be scheduled again.


Made with [Cursor](https://cursor.com)