### PR TITLE
fix: correct OVN pod network MTU for jumbo frames

### DIFF
--- a/scripts/post-install.sh
+++ b/scripts/post-install.sh
@@ -73,13 +73,8 @@ function update_hbn_ovn_manifests() {
 
     # Update ovn-configuration.yaml for DPUDeployment
     if [ -f "${POST_INSTALL_DIR}/ovn-configuration.yaml" ]; then
-        local ovn_mtu=""
-
-        if [ "$NODES_MTU" != "1500" ]; then
-            ovn_mtu=$((NODES_MTU - 60))
-        else
-            ovn_mtu=1400
-        fi
+        # OVN-Kubernetes uses 100 bytes of overhead for Geneve encapsulation.
+        local ovn_mtu=$((NODES_MTU - 100))
 
         log "INFO" "ovn-configuration will be set with MTU:$ovn_mtu"
         update_file_multi_replace \


### PR DESCRIPTION
Found  as part of the GA User Manual review (and alignment against this automation repo).

The existing branches use inconsistent encapsulation overheads: the 1500-byte profile maps to 1400, while the 9000-byte profile maps to 8940.

Use OVN-Kubernetes' 100-byte Geneve overhead for both supported MTU profiles. This preserves 1400 for the default and produces 8900 for jumbo frames.