### PR TITLE
Install OVN resource injector as a Helm release

### DIFF
--- a/scripts/enable-ovn-injector.sh
+++ b/scripts/enable-ovn-injector.sh
@@ -23,18 +23,11 @@ INJECTOR_WEBHOOK_PORT=19443
 INJECTOR_HEALTH_PROBE_PORT=18081
 INJECTOR_METRICS_PORT=29091
 
-log [INFO] "Enabling OVN resource injector..."
+log [INFO] "Enabling OVN resource injector (chart ${INJECTOR_CHART_VERSION})..."
 
-rm -rf "$GENERATED_DIR/ovn-injector" || true
-mkdir -p "$GENERATED_DIR/ovn-injector"
-
-
-helm pull "${OVN_CHART_URL}/ovn-kubernetes-chart" \
+if ! helm upgrade --install -n "${OVNK_NAMESPACE}" ovn-kubernetes \
+    "${OVN_CHART_URL}/ovn-kubernetes-chart" \
     --version "${INJECTOR_CHART_VERSION}" \
-    --untar -d "$GENERATED_DIR/ovn-injector"
-
-helm template -n ${OVNK_NAMESPACE} ovn-kubernetes \
-    "$GENERATED_DIR/ovn-injector/ovn-kubernetes-chart" \
     --set ovn-kubernetes-resource-injector.enabled=true \
     --set ovn-kubernetes-resource-injector.resourceName="${INJECTOR_RESOURCE_NAME}" \
     --set ovn-kubernetes-resource-injector.prioritizeOffloading=false \
@@ -47,11 +40,10 @@ helm template -n ${OVNK_NAMESPACE} ovn-kubernetes \
     --set nodeWithoutDPUManifests.enabled=false \
     --set dpuManifests.enabled=false \
     --set controlPlaneManifests.enabled=false \
-    --set commonManifests.enabled=false > "$GENERATED_DIR/ovn-injector-output.yaml"
-
-oc apply -f "$GENERATED_DIR/ovn-injector-output.yaml"
-
-rm -rf "$GENERATED_DIR/ovn-injector"
+    --set commonManifests.enabled=false; then
+    log [ERROR] "Helm deployment of OVN resource injector failed"
+    exit 1
+fi
 
 # Wait for the webhook deployment to roll out
 log [INFO] "Waiting for OVN resource injector deployment to roll out..."


### PR DESCRIPTION
## Summary
- Replace `helm template` + `oc apply` with `helm upgrade --install` so the OVN resource injector is a real Helm release (`ovn-kubernetes` in `openshift-ovn-kubernetes`).
- Chart URL, version, resource name, and webhook ports stay env-driven; other OVN chart manifests remain disabled.
- Lets later injector chart upgrades take over the same objects instead of leaving them unmanaged.

## Test plan
- [ ] `make enable-ovn-injector` on a cluster that does not yet have the injector: Helm release is created, webhook deployment rolls out, MutatingWebhookConfiguration and `dpf-ovn-kubernetes` NAD exist.
- [ ] Re-run `make enable-ovn-injector`: `helm upgrade --install` succeeds (idempotent).
- [ ] On a cluster that still has injector objects from the old `oc apply` path: confirm whether Helm can adopt them, or if a one-time delete/recreate is needed (this change does not pass `--take-ownership`).

Made with [Cursor](https://cursor.com)