### PR TITLE
Fast fail: close inherited pipe FDs in backgrounded virt-install

### DIFF
--- a/scripts/vm.sh
+++ b/scripts/vm.sh
@@ -79,7 +79,7 @@ _create_vm() {
             --cpu host-passthrough \
             --boot uefi \
             --noautoconsole \
-            --wait=-1 &
+            --wait=-1 > /dev/null 2>&1 &
 }
 
 _wait_for_vms_running() {


### PR DESCRIPTION
When make all runs through a tee pipeline (as the CI step does), backgrounded `virt-install --wait=-1` processes inherit the pipe's write FDs. If make fails mid-deployment, those orphaned processes keep the pipe open indefinitely, preventing tee from exiting and the SSH session from returning. The Prow job then hangs as "pending" until its 5-hour timeout instead of failing immediately. Hit this issue [here](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/84170/rehearse-84170-pull-ci-rh-ecosystem-edge-openshift-dpf-main-deploy-cluster-doca4/2092929635938471936).

Redirecting virt-install's stdout/stderr to /`dev/null` breaks the FD inheritance so the pipeline collapses cleanly on failure.