### PR TITLE
chore: bump DPF to v26.4.1 GA and use upstream helm repo

### DIFF
--- a/ci/env.defaults
+++ b/ci/env.defaults
@@ -21,8 +21,8 @@ GENERATED_POST_INSTALL_DIR=${GENERATED_POST_INSTALL_DIR:-manifests/generated/pos
 SSH_KEY=${SSH_KEY:-~/.ssh/id_ed25519.pub}
 
 # DPF Configuration
-DPF_VERSION=${DPF_VERSION:-26.4.0-298f9443}
-DPF_HELM_REPO_URL=${DPF_HELM_REPO_URL:-oci://ghcr.io/souleb/doca-platform/charts}
+DPF_VERSION=${DPF_VERSION:-v26.4.1}
+DPF_HELM_REPO_URL=${DPF_HELM_REPO_URL:-https://helm.ngc.nvidia.com/nvidia}
 OVN_CHART_URL=${OVN_CHART_URL:-oci://ghcr.io/mellanox/charts}
 OVN_TEMPLATE_CHART_URL=${OVN_TEMPLATE_CHART_URL:-oci://ghcr.io/mellanox/charts}
 OVN_CHART_VERSION=${OVN_CHART_VERSION:-v26.4.1-ocp-release-v4.22}


### PR DESCRIPTION
As DPF v26.4.1 is close to the release we can bump the version to the official GA.