### PR TITLE
update bluefield-ocp

### DIFF
--- a/ci/env.defaults
+++ b/ci/env.defaults
@@ -136,7 +136,7 @@ BFB_STORAGE_CLASS=${BFB_STORAGE_CLASS:-lvms-vg1}
 BFB_URL=${BFB_URL:-https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260715-0/aarch64/rhcos-10.2.20260715-0-nvidiabluefield.aarch64.bfb}
 
 # Bluefield image layer
-BLUEFIELD_OCP_IMAGE=${BLUEFIELD_OCP_IMAGE:-quay.io/eelgaev/bluefield-ocp:4.22.7-doca3.4.2-2026-08-25}
+BLUEFIELD_OCP_IMAGE=${BLUEFIELD_OCP_IMAGE:-quay.io/edge-infrastructure/bluefield-ocp:4.22.7}
 
 # Kubeconfig
 KUBECONFIG=${KUBECONFIG:-./kubeconfig}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default BlueField OpenShift image to version 4.22.7.
  * Ensures new environments use the latest configured image by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->