### PR TITLE
Update helm repo URL

### DIFF
--- a/ci/env.defaults
+++ b/ci/env.defaults
@@ -22,7 +22,7 @@ SSH_KEY=${SSH_KEY:-~/.ssh/id_ed25519.pub}
 
 # DPF Configuration
 DPF_VERSION=${DPF_VERSION:-v26.4.1}
-DPF_HELM_REPO_URL=${DPF_HELM_REPO_URL:-https://helm.ngc.nvidia.com/nvidia}
+DPF_HELM_REPO_URL=${DPF_HELM_REPO_URL:-https://helm.ngc.nvidia.com/nvidia/doca}
 OVN_CHART_URL=${OVN_CHART_URL:-oci://ghcr.io/mellanox/charts}
 OVN_TEMPLATE_CHART_URL=${OVN_TEMPLATE_CHART_URL:-oci://ghcr.io/mellanox/charts}
 OVN_CHART_VERSION=${OVN_CHART_VERSION:-v26.4.1-ocp-release-v4.22}


### PR DESCRIPTION
After https://github.com/rh-ecosystem-edge/openshift-dpf/pull/350 the dpf-operator chart v26.4.1 exists at https://helm.ngc.nvidia.com/nvidia/doca, not https://helm.ngc.nvidia.com/nvidia.