### PR TITLE
Bump hypershift timeout

### DIFF
--- a/scripts/dpf.sh
+++ b/scripts/dpf.sh
@@ -327,7 +327,7 @@ function deploy_hypershift() {
     else
         log [INFO] "Installing latest hypershift operator"
         install_hypershift
-        wait_for_pods "hypershift" "app=operator" 30 5
+        wait_for_pods "hypershift" "app=operator" 60 10
     fi
 
     # Step 4: Deploy MetalLB operator if HYPERSHIFT_API_IP is configured (multi-node clusters only)


### PR DESCRIPTION
This [daily run](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/periodic-ci-rh-ecosystem-edge-openshift-dpf-main-daily-network-doca4/2093858860203773952/artifacts/daily-network-doca4/dpf-hypervisor-deploy-cluster/build-log.txt) failed because of the hypershift timeout being too tight.
This PR changes the HyperShift operator wait from 30 5 (150s) to 60 10 (600s), matching what most other operator waits in the codebase use.