### PR TITLE
Remove redundant chmod +x

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -275,7 +275,6 @@ install-helm:
 .PHONY: run-dpf-sanity
 run-dpf-sanity:
 	@echo "Running $(SANITY_CHECKS_SCRIPT) ..."
-	@chmod +x $(SANITY_CHECKS_SCRIPT)
 	@$(SANITY_CHECKS_SCRIPT)
 
 # E2E Tests (library-import based, runs against pre-existing deployment)


### PR DESCRIPTION
All scripts (including dpf-sanity-checks.sh) already have 755 permissions in git. The chmod +x in the Makefile was redundant, and it is breaking CI automation, i.e.: [example](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/openshift_release/83376/rehearse-83376-pull-ci-rh-ecosystem-edge-openshift-dpf-main-sanity-doca4/2094055418547408896/artifacts/sanity-doca4/dpf-hypervisor-sanity/build-log.txt):

```
=== DPF Sanity Test ===
Running scripts/dpf-sanity-checks.sh ...
chmod: changing permissions of 'scripts/dpf-sanity-checks.sh': Operation not permitted
make: *** [Makefile:278: run-dpf-sanity] Error 1
Sanity Test Failed
```