### PR TITLE
[release-4.22] Set image versions from registry.redhat.io

### DIFF
--- a/ci/env.defaults
+++ b/ci/env.defaults
@@ -135,7 +135,7 @@ BFB_STORAGE_CLASS=${BFB_STORAGE_CLASS:-lvms-vg1}
 BFB_URL=${BFB_URL:-https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260715-0/aarch64/rhcos-10.2.20260715-0-nvidiabluefield.aarch64.bfb}
 
 # Bluefield image layer
-BLUEFIELD_OCP_IMAGE=${BLUEFIELD_OCP_IMAGE:-quay.io/edge-infrastructure/bluefield-ocp:4.22.7}
+BLUEFIELD_OCP_IMAGE=${BLUEFIELD_OCP_IMAGE:-}
 
 # Kubeconfig
 KUBECONFIG=${KUBECONFIG:-./kubeconfig}
@@ -168,16 +168,16 @@ SANITY_TESTS_PING_COUNT=${SANITY_TESTS_PING_COUNT:-20}
 SANITY_TESTS_PING_HBN_TO_HBN_PODS=${SANITY_TESTS_PING_HBN_TO_HBN_PODS:-false}
 
 # DPU Worker Config Helm Chart Configuration
-DPU_WORKER_CONFIG_CHART_URL=${DPU_WORKER_CONFIG_CHART_URL:-oci://quay.io/redhat-user-workloads/dpu-kit-for-nvidia-operator-tenant/dpu-worker-config-chart}
+DPU_WORKER_CONFIG_CHART_URL=${DPU_WORKER_CONFIG_CHART_URL:-oci://registry.redhat.io/dpu-kit-for-nvidia/dpu-worker-config-chart}
 DPU_WORKER_CONFIG_CHART_VERSION=${DPU_WORKER_CONFIG_CHART_VERSION:-4.22.0}
 
 # DPF HCP Provisioner Operator Configuration
-DPF_HCP_PROVISIONER_OPERATOR_CHART_URL=${DPF_HCP_PROVISIONER_OPERATOR_CHART_URL:-oci://quay.io/redhat-user-workloads/dpu-kit-for-nvidia-operator-tenant/dpf-hcp-provisioner-chart}
+DPF_HCP_PROVISIONER_OPERATOR_CHART_URL=${DPF_HCP_PROVISIONER_OPERATOR_CHART_URL:-oci://registry.redhat.io/dpu-kit-for-nvidia/dpf-hcp-provisioner-chart}
 DPF_HCP_PROVISIONER_OPERATOR_NAMESPACE=${DPF_HCP_PROVISIONER_OPERATOR_NAMESPACE:-dpf-hcp-provisioner-system}
 # When empty, helm pull/upgrade omits --version and fetches the highest available semver from the OCI registry.
 # Helm does not support "latest" as a chart version (not valid semver).
 DPF_HCP_PROVISIONER_OPERATOR_VERSION=${DPF_HCP_PROVISIONER_OPERATOR_VERSION:-4.22.0}
-DPF_HCP_PROVISIONER_OPERATOR_IMAGE_REPO=${DPF_HCP_PROVISIONER_OPERATOR_IMAGE_REPO:-quay.io/redhat-user-workloads/dpu-kit-for-nvidia-operator-tenant/dpf-hcp-provisioner-rhel10-operator-4-22}
-DPF_HCP_PROVISIONER_OPERATOR_IMAGE_TAG=${DPF_HCP_PROVISIONER_OPERATOR_IMAGE_TAG:-latest}
+DPF_HCP_PROVISIONER_OPERATOR_IMAGE_REPO=${DPF_HCP_PROVISIONER_OPERATOR_IMAGE_REPO:-registry.redhat.io/dpu-kit-for-nvidia/dpf-hcp-provisioner-rhel10-operator}
+DPF_HCP_PROVISIONER_OPERATOR_IMAGE_TAG=${DPF_HCP_PROVISIONER_OPERATOR_IMAGE_TAG:-v4.22}
 DPFHCPPROVISIONER_PULL_SECRET_NAME=${DPFHCPPROVISIONER_PULL_SECRET_NAME:-my-pull-secret}
 DPFHCPPROVISIONER_SSH_SECRET_NAME=${DPFHCPPROVISIONER_SSH_SECRET_NAME:-my-ssh-key}


### PR DESCRIPTION
This PR sets the `dpf-hcp-provisioner-operator` versions to use the official ones from `registry.redhat.io`.

For `bluefield-ocp` we use empty value to employ the automated BlueField-OCP image lookup so it selects the image from the default registry.
https://github.com/rh-ecosystem-edge/dpf-hcp-provisioner-operator/blob/release-4.22/helm/dpf-hcp-provisioner-operator/templates/dpfhcpprovisionerconfig.yaml#L14 