### PR TITLE
fix: authenticate Helm against registry.redhat.io for OCI chart pulls

### DIFF
--- a/scripts/dpf.sh
+++ b/scripts/dpf.sh
@@ -179,6 +179,7 @@ function deploy_dpf_hcp_provisioner_operator() {
         --namespace ${DPF_HCP_PROVISIONER_OPERATOR_NAMESPACE} \
         --create-namespace \
         --disable-openapi-validation \
+        --registry-config "${OPENSHIFT_PULL_SECRET}" \
         ${version_flag} \
         --set image.repository=${DPF_HCP_PROVISIONER_OPERATOR_IMAGE_REPO} \
         --set image.pullPolicy=Always \
@@ -218,6 +219,7 @@ function deploy_dpu_worker_config() {
         --namespace ${DPF_HCP_PROVISIONER_OPERATOR_NAMESPACE} \
         --create-namespace \
         --disable-openapi-validation \
+        --registry-config "${OPENSHIFT_PULL_SECRET}" \
         ${version_flag}; then
         log [INFO] "Helm release 'dpu-worker-config' deployed successfully"
     else


### PR DESCRIPTION
PR #360 moved dpu-worker-config-chart and dpf-hcp-provisioner-chart from public quay.io sources to registry.redhat.io, which requires authentication. Helm's OCI client uses its own credential store, separate from the cluster/DPU pull secret wired in elsewhere (Assisted Installer, DPFHCPProvisioner), so both helm upgrade --install calls started failing with 401 Unauthorized.

Point both installs at the existing OPENSHIFT_PULL_SECRET file via --registry-config instead of adding a new secret or a persistent `helm registry login` step. That file is already scp'd to the remote host before deployment and already contains a registry.redhat.io entry, verified with a manual helm pull of both charts on NVIDIA OCP/DPF setup-8.