### PR TITLE
Add oc adm wait-for-stable-cluster verification to deploy

### DIFF
--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -155,6 +155,12 @@ verify_deployment() {
     fi
     
     log "INFO" ""
+    log "INFO" "=== 4. Waiting for stable cluster ==="
+    if ! oc adm wait-for-stable-cluster --minimum-stable-period=2m --timeout=20m; then
+        ((failed++)) || true
+    fi
+
+    log "INFO" ""
     log "INFO" "================================================================================"
     if [[ $failed -eq 0 ]]; then
         log "INFO" "All verification checks PASSED"


### PR DESCRIPTION
Some times ([example](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/rh-ecosystem-edge_openshift-dpf/375/pull-ci-rh-ecosystem-edge-openshift-dpf-release-4.22-deploy-cluster/2095672433263513600) here) the deployment succeds but then sanity fails because the cluster operators have not stabilized yet.

This PR adds `oc adm wait-for-stable-cluster` as a final verification step in the verify deployment target.