### PR TITLE
fix: set operatorConfig.deploy=true for maintenance-operator chart

### DIFF
--- a/manifests/helm-charts-values/maintenance-operator-values.yaml
+++ b/manifests/helm-charts-values/maintenance-operator-values.yaml
@@ -1,6 +1,7 @@
 # Maintenance Operator Chart configuration for OpenShift DPF
 # Based on doca-platform/deploy/helmfiles/values/maintenance-operator-chart.yaml
 operatorConfig:
+  deploy: true
   maxParallelOperations: 60%
 operator:
   affinity:


### PR DESCRIPTION
Chart 0.3.0 (pinned since ~Aug 31) requires operatorConfig.deploy=true to render the MaintenanceOperatorConfig CR; without it maxParallelOperations is silently discarded and the operator falls back to its built-in default of 1, serializing all node maintenance/drain operations one at a time.

Observed on an internal OCP+DPF test environment: DPU provisioning went from parallel (~36-40 min for both DPUs) to serial (~35-40 min per DPU, one after the other) starting Sep 1, extending job time from ~2.1h to ~2.7-3.3h.