### PR TITLE
[release-4.22] fix: set operatorConfig.deploy=true for maintenance-operator chart

### DIFF
--- a/manifests/helm-charts-values/maintenance-operator-values.yaml
+++ b/manifests/helm-charts-values/maintenance-operator-values.yaml
@@ -1,6 +1,7 @@
 # Maintenance Operator Chart configuration for OpenShift DPF
 # Based on doca-platform/deploy/helmfiles/values/maintenance-operator-chart.yaml
 operatorConfig:
+  deploy: true
   maxParallelOperations: 60%
 operator:
   affinity:


### PR DESCRIPTION
## Summary
* Backport of #386 to `release-4.22`
* `release-4.22` picked up Maintenance Operator 0.3.0 via `56890e3`
  ("Bump GitOps to 1.21.3 and Maintenance Operator to 0.3.0"), so it has
  the same exposure as `main`
* Add `operatorConfig.deploy: true` to `maintenance-operator-values.yaml`
* No other values changed

## Background
Maintenance Operator chart `0.3.0` gates rendering of the
`MaintenanceOperatorConfig` CR behind `operatorConfig.deploy: true`. Our
values file never set that field, so `helm upgrade --install` reported
success but the CR was never created. With no CR present, the operator
falls back to its in-code default of `maxParallelOperations: 1`,
serializing node maintenance operations that were previously parallel.

Observed impact on an internal OCP+DPF test environment: DPU provisioning
went from both DPUs draining together (~36-40 min total) to one DPU at a
time (~35-40 min each, sequential), extending job time from ~2.1h to
~2.7-3.3h.

## Test plan
* Re-deploy `release-4.22` with this values file; confirm
  `kubectl get maintenanceoperatorconfig -n dpf-operator-system` returns the
  `default` object with `maxParallelOperations: 60%`.
* Confirm both DPU node maintenance objects on a fresh install/reprovision
  drain concurrently.